### PR TITLE
LinterとFormatter、型チェックツールを設定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint fix format
+.PHONY: lint fix format typecheck
 
 lint:
 	rye run ruff check

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ fix:
 
 format:
 	rye run ruff format
+
+typecheck:
+	rye run mypy src/ --strict

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: lint fix format
+
+lint:
+	rye run ruff check
+
+fix:
+	rye run ruff check --fix
+
+format:
+	rye run ruff format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "hatchling.build"
 managed = true
 dev-dependencies = [
     "ruff>=0.6.8",
+    "mypy>=1.11.2",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ build-backend = "hatchling.build"
 
 [tool.rye]
 managed = true
-dev-dependencies = []
+dev-dependencies = [
+    "ruff>=0.6.8",
+]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -26,6 +26,7 @@ pydantic==2.9.2
     # via fastapi
 pydantic-core==2.23.4
     # via pydantic
+ruff==0.6.8
 sniffio==1.3.1
     # via anyio
 starlette==0.38.6

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -22,6 +22,9 @@ h11==0.14.0
     # via uvicorn
 idna==3.10
     # via anyio
+mypy==1.11.2
+mypy-extensions==1.0.0
+    # via mypy
 pydantic==2.9.2
     # via fastapi
 pydantic-core==2.23.4
@@ -33,6 +36,7 @@ starlette==0.38.6
     # via fastapi
 typing-extensions==4.12.2
     # via fastapi
+    # via mypy
     # via pydantic
     # via pydantic-core
 uvicorn==0.30.6

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ class LgtmImageCreateResponse(BaseModel):
 
 
 @app.get("/lgtm-images", response_model=List[LgtmImageRandomListResponse])
-async def extract_random_lgtm_images():
+async def extract_random_lgtm_images() -> List[LgtmImageRandomListResponse]:
     return [
         LgtmImageRandomListResponse(
             id="1",
@@ -36,7 +36,7 @@ async def extract_random_lgtm_images():
 
 
 @app.post("/lgtm-images", response_model=LgtmImageCreateResponse)
-async def create_lgtm_image(lgtm_image_create: LgtmImageCreateRequest):
+async def create_lgtm_image(lgtm_image_create: LgtmImageCreateRequest) -> LgtmImageCreateResponse:
     return LgtmImageCreateResponse(
         imageUrl="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
     )
@@ -45,7 +45,7 @@ async def create_lgtm_image(lgtm_image_create: LgtmImageCreateRequest):
 @app.get(
     "/lgtm-images/recently-created", response_model=LgtmImageRecentlyCreatedListResponse
 )
-async def extract_recently_created_lgtm_images():
+async def extract_recently_created_lgtm_images() -> List[LgtmImageRecentlyCreatedListResponse]:
     return [
         LgtmImageRecentlyCreatedListResponse(
             id="1",
@@ -54,7 +54,7 @@ async def extract_recently_created_lgtm_images():
     ]
 
 
-def start():
+def start() -> None:
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,32 +5,53 @@ import uvicorn
 
 app = FastAPI(title="LGTM Cat API")
 
+
 class LgtmImageRandomListResponse(BaseModel):
     id: str
     url: str
+
 
 class LgtmImageRecentlyCreatedListResponse(BaseModel):
     id: str
     url: str
 
+
 class LgtmImageCreateRequest(BaseModel):
     image: str
     imageExtension: str
 
+
 class LgtmImageCreateResponse(BaseModel):
     imageUrl: str
 
+
 @app.get("/lgtm-images", response_model=List[LgtmImageRandomListResponse])
 async def extract_random_lgtm_images():
-    return [LgtmImageRandomListResponse(id="1", url="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp")]
+    return [
+        LgtmImageRandomListResponse(
+            id="1",
+            url="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+        )
+    ]
+
 
 @app.post("/lgtm-images", response_model=LgtmImageCreateResponse)
 async def create_lgtm_image(lgtm_image_create: LgtmImageCreateRequest):
-    return LgtmImageCreateResponse(imageUrl="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp")
+    return LgtmImageCreateResponse(
+        imageUrl="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+    )
 
-@app.get("/lgtm-images/recently-created", response_model=LgtmImageRecentlyCreatedListResponse)
+
+@app.get(
+    "/lgtm-images/recently-created", response_model=LgtmImageRecentlyCreatedListResponse
+)
 async def extract_recently_created_lgtm_images():
-    return [LgtmImageRecentlyCreatedListResponse(id="1", url="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp")]
+    return [
+        LgtmImageRecentlyCreatedListResponse(
+            id="1",
+            url="https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+        )
+    ]
 
 
 def start():


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/2

# この PR で対応する範囲 / この PR で対応しない範囲
以下を実施。
LinterとFormatter、型チェックツールの設定
上記の実行とエラー箇所の修正

CIの設定は別の課題で対応する。

# 変更点概要
LinterとFormatterとして`ruff`、形チェックツールとして`mypy`をインストール。
上記を実行するための`Makefile`も追加している。

また上記を実行し、エラー発生箇所については修正を行なった。

# 補足情報
Makefileの内容は [lgtm-cat-processor](https://github.com/nekochans/lgtm-cat-processor/blob/main/Makefile) と同じ設定としている。