### PR TITLE
CIワークフローにテストジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,34 @@ jobs:
 
       - name: Mypy
         run: uv run mypy src/ --strict
+
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Docker set up
+        run: docker compose up --build -d
+        env:
+          TEST_DATABASE_ROOT_PASSWORD: ${{ secrets.TEST_DATABASE_ROOT_PASSWORD }}
+          TEST_DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Test
+        run: make test
+        env:
+          TEST_DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}
+          PLANETSCALE_ORG_NAME: ${{ secrets.PLANETSCALE_ORG_NAME }}
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          PLANETSCALE_DATABASE_NAME: ${{ secrets.PLANETSCALE_DATABASE_NAME }}
+          PLANETSCALE_BRANCH_NAME: ${{ secrets.PLANETSCALE_BRANCH_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           enable-cache: true
 
       - name: Docker set up
-        run: docker compose up --build -d
+        run: docker compose up --build -d --wait
         env:
           TEST_DATABASE_ROOT_PASSWORD: ${{ secrets.TEST_DATABASE_ROOT_PASSWORD }}
           TEST_DATABASE_PASSWORD: ${{ secrets.TEST_DATABASE_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ LGTMeow用のFastAPIベースのWeb APIです。依存関係管理には`uv`を�
 - `make fix` - Ruffリンターで自動修正
 - `make format` - Ruffでコードをフォーマット
 - `make typecheck` - mypyで`src/`ディレクトリを厳格モードで型チェック
+- `make test` - pytestですべてのテストを実行
 
 すべてのコマンドは正しい仮想環境を使用するために`uv run`経由で実行する必要があります。Makefileは既にこれに対応しています。
 
@@ -89,10 +90,11 @@ APIはシンプルなRESTパターンに従い、3つのエンドポイントが
 - `make fix`で自動修正し、その後`make format`でフォーマットします
 
 ### CIパイプライン
-CIは3つの独立したジョブを実行します：
+CIは4つの独立したジョブを実行します：
 1. **ci** - Ruffリントチェック
 2. **format** - Ruffフォーマットチェック
 3. **typecheck** - mypy厳格型チェック
+4. **test** - pytestによるテスト実行
 
 PRをマージするにはすべてのジョブがパスする必要があります。
 

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ format:
 
 typecheck:
 	uv run mypy src/ --strict
+
+test:
+	uv run pytest -vv -s src/ tests/

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ make format
 
 # 型チェック（strictモード）
 make typecheck
+
+# すべてのテストを実行
+make test
 ```
 
 すべてのコマンドは正しい仮想環境を使用するために`uv run`経由で実行されます（Makefileが自動的に対応）。
@@ -105,6 +108,7 @@ make typecheck
   - ci (Ruffリントチェック)
   - format (Ruffフォーマットチェック)
   - typecheck (mypy厳格型チェック)
+  - test (pytestによるテスト実行)
 
 ## API仕様
 

--- a/compose.yml
+++ b/compose.yml
@@ -14,3 +14,9 @@ services:
     volumes:
       - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${TEST_DATABASE_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s


### PR DESCRIPTION
# issueURL

#16

# この PR で対応する範囲 / この PR で対応しない範囲

この PR で対応する範囲：
- CIワークフローへのテストジョブの追加
- テストジョブの実行環境設定（Docker Compose、環境変数）
- MySQL起動待機のためのヘルスチェック設定
- ドキュメントへのテストコマンドとCIジョブの説明の追加

この PR で対応しない範囲：
- テストコード自体の実装（既存のテストコードを実行）

# 変更点概要

CIパイプラインに `test` ジョブを追加し、PRマージ前に自動的にテストが実行されるように変更。

- `.github/workflows/ci.yml`: Docker ComposeでMySQL環境をセットアップし、pytestを実行する `test` ジョブを追加
  - `--wait`オプションによるMySQLヘルスチェック待機を追加（MySQLが完全に準備できてからテストを実行するため） 
- `compose.yml`: MySQLコンテナのhealthcheck設定を追加（`mysqladmin ping`による準備完了検出）
- `Makefile`: `make test` ターゲットを追加
- `CLAUDE.md`, `README.md`: CIジョブの説明とテストコマンドの使い方を更新

これにより、既存の lint、format、typecheck に加えて、テストもCI上で自動実行されるようになる。

## MySQL接続エラー対策

Docker起動直後にテストを実行すると「Lost connection to MySQL server during query」エラーが発生する問題が発生していた。(CI上だけでなくローカルでも発生) 
ヘルスチェックによる待機処理を追加することで、MySQLが完全に準備できてからテストを実行できるように変更した。

## GitHub Actions Secretsへの登録
CIで必要となる環境変数については、Secretsから取得を行なっている。
Secretsへは登録済み。

# 補足
GitHub Actions上でテストが実行され、テストケースをパスしていることを確認済み。
https://github.com/nekochans/lgtm-cat-api/actions/runs/18631100754/job/53115873567?pr=19