### PR TITLE
APIレスポンスにX-Request-Idヘッダーを追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.config import get_log_level
 from src.log.logger import setup_logging
+from src.log.request_id import get_request_id
 from src.presentation.middleware.logging_middleware import LoggingMiddleware
+from src.presentation.middleware.request_id_middleware import RequestIdMiddleware
 from src.presentation.router import lgtm_image_router
 
 # ロギング設定の初期化
@@ -13,8 +17,43 @@ setup_logging(log_level=get_log_level())
 
 app = FastAPI(title="LGTM Cat API")
 
-# ミドルウェアの登録
+
+# 例外ハンドラの登録（X-Request-Idヘッダーを追加）
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request: Request, exc: Exception) -> Response:
+    """HTTP例外ハンドラ - X-Request-Idヘッダーを追加"""
+    # 型アサーション: add_exception_handlerで登録した型が渡される
+    http_exc = (
+        exc
+        if isinstance(exc, StarletteHTTPException)
+        else StarletteHTTPException(status_code=500)
+    )
+    response = JSONResponse(
+        status_code=http_exc.status_code,
+        content={"detail": http_exc.detail},
+    )
+    request_id = get_request_id()
+    if request_id:
+        response.headers["X-Request-Id"] = request_id
+    return response
+
+
+@app.exception_handler(Exception)
+async def general_exception_handler(request: Request, exc: Exception) -> Response:
+    """一般例外ハンドラ - X-Request-Idヘッダーを追加"""
+    response = JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
+    request_id = get_request_id()
+    if request_id:
+        response.headers["X-Request-Id"] = request_id
+    return response
+
+
+# ミドルウェアの登録（後に登録したものが先に実行される）
 app.add_middleware(LoggingMiddleware)
+app.add_middleware(RequestIdMiddleware)
 
 # ルーターの登録
 app.include_router(lgtm_image_router.router)

--- a/src/presentation/middleware/logging_middleware.py
+++ b/src/presentation/middleware/logging_middleware.py
@@ -7,7 +7,6 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import Response
 
 from src.log.logger import get_logger
-from src.log.request_id import generate_request_id, set_request_id
 
 logger = get_logger(__name__)
 
@@ -16,10 +15,6 @@ class LoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
-        # X-Request-IdヘッダーからリクエストIDを取得、なければ生成
-        request_id = request.headers.get("X-Request-Id") or generate_request_id()
-        set_request_id(request_id)
-
         # リクエスト受信ログ
         logger.info(
             "Request received",

--- a/src/presentation/middleware/request_id_middleware.py
+++ b/src/presentation/middleware/request_id_middleware.py
@@ -1,0 +1,24 @@
+# 絶対厳守:編集前に必ずAI実装ルールを読む
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+from src.log.request_id import generate_request_id, set_request_id
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        # X-Request-IdヘッダーからリクエストIDを取得、なければ生成
+        request_id = request.headers.get("X-Request-Id") or generate_request_id()
+        set_request_id(request_id)
+
+        # リクエスト処理
+        response = await call_next(request)
+
+        # レスポンスヘッダーにX-Request-Idを追加
+        response.headers["X-Request-Id"] = request_id
+
+        return response


### PR DESCRIPTION
# issueURL

#22

# この PR で対応する範囲 / この PR で対応しない範囲

この PR で対応する範囲：
- APIレスポンスにX-Request-Idヘッダーを追加
- RequestIdMiddlewareの新規作成
- LoggingMiddlewareの責務分離
- エラーレスポンスへのX-Request-Id付与

この PR で対応しない範囲：
- リクエストバリデーションエラーのハンドリング（POSTエンドポイント実装時に対応）

# 変更点概要

すべてのAPIレスポンス（正常・エラー両方）に`X-Request-Id`ヘッダーを追加。
これによりトレーサビリティが向上し、ログとの紐付けが容易となる。

## 実装内容

### 1. RequestIdMiddlewareの新規作成
- リクエストIDの生成・設定
- レスポンスヘッダーへの`X-Request-Id`追加
- LoggingMiddlewareから責務を分離

### 2. LoggingMiddlewareの修正
- リクエストID生成ロジックを削除
- ロギングのみに責務を絞る

### 3. 例外ハンドラの追加（main.py）
- `@app.exception_handler(StarletteHTTPException)` - 404などのHTTPエラー用
- `@app.exception_handler(Exception)` - 500などの一般例外用
- エラーレスポンスにもX-Request-Idヘッダーを付与

# 補足情報

## 例外ハンドラの動作について

### 実装した例外ハンドラ

1. **`@app.exception_handler(StarletteHTTPException)`**
   - HTTPステータスコード付きの例外を処理
   - レスポンスにX-Request-Idヘッダーを追加

2. **`@app.exception_handler(Exception)`**
   - その他すべての例外を処理（フォールバック）
   - レスポンスにX-Request-Idヘッダーを追加

### 各ハンドラが呼ばれるケース

#### StarletteHTTPException ハンドラ

**呼ばれるケース：**
- 存在しないエンドポイントへのアクセス（404 Not Found）
  - 例: `GET /nonexistent`
- 許可されていないHTTPメソッド（405 Method Not Allowed）
  - 例: `POST /lgtm-images`（GETのみ定義されている）
- ミドルウェア内で`HTTPException`を明示的にraise
- 依存性注入（Depends）で`HTTPException`をraise

**実際の動作確認済み：**
```bash
curl -i http://localhost:8000/nonexistent
# → StarletteHTTPException ハンドラが呼ばれ、X-Request-Id付きで404を返す
```

#### Exception ハンドラ

**呼ばれるケース：**
- ミドルウェア内で予期しない例外が発生
  - 例: `RequestIdMiddleware`内でのエラー
- 依存性注入で一般例外が発生
  - 例: `create_db_session()`でDB接続エラー
- ルーターレベルの例外

**重要な注意点：**

⚠️ **コントローラー内の例外は到達しない**

現在の実装では、コントローラー内ですべての例外をキャッチしているため、例外ハンドラには到達しません：

```python
# src/presentation/controller/lgtm_image_controller.py
try:
    # ユースケース実行
    images = await ExtractRandomLgtmImagesUsecase.execute(...)
    return create_json_response(response)
except ErrRecordCount:
    # ビジネスエラーをキャッチ
    return JSONResponse(status_code=404, content={...})
except Exception as e:
    # すべての例外をキャッチ ← ここで止まる
    return JSONResponse(status_code=500, content={...})
```

### リクエスト処理の流れと例外ハンドリング

```
クライアント
  ↓
RequestIdMiddleware
  ├─ 例外発生 → Exception ハンドラ
  ↓
LoggingMiddleware
  ├─ 例外発生 → Exception ハンドラ
  ↓
ルーティング
  ├─ 存在しないパス → StarletteHTTPException ハンドラ
  ├─ 不正なメソッド → StarletteHTTPException ハンドラ
  ↓
依存性注入（Depends）
  ├─ HTTPException → StarletteHTTPException ハンドラ
  ├─ その他の例外 → Exception ハンドラ
  ↓
コントローラー
  ├─ ErrRecordCount → コントローラー内でキャッチ → 404 JSONResponse
  ├─ Exception → コントローラー内でキャッチ → 500 JSONResponse
  └─ 正常処理 → 200 JSONResponse
  ↓
RequestIdMiddleware（戻り）
  └─ すべてのレスポンスにX-Request-Idを追加
  ↓
クライアント
```

### まとめ

**コントローラー内のエラーは**、コントローラー自身が処理し、`RequestIdMiddleware`を通過してX-Request-Idが付与される。