### PR TITLE
ヘルスチェックエンドポイントの追加

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from src.presentation.router import health_check_router
 from src.config import get_log_level
 from src.log.logger import setup_logging
 from src.log.request_id import get_request_id
@@ -73,6 +74,7 @@ app.add_middleware(RequestIdMiddleware)
 
 # ルーターの登録
 app.include_router(lgtm_image_router.router)
+app.include_router(health_check_router.router)
 
 
 def start() -> None:

--- a/src/presentation/controller/health_check_controller.py
+++ b/src/presentation/controller/health_check_controller.py
@@ -1,0 +1,16 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from src.presentation.controller.response_helper import create_json_response
+
+
+class HealthCheckResponse(BaseModel):
+    status_code: int = Field(..., alias="statusCode", description="ステータスコード")
+
+
+class HealthCheckController:
+    @staticmethod
+    def check() -> JSONResponse:
+        response = HealthCheckResponse(statusCode=200)
+        return create_json_response(response, status_code=200)

--- a/src/presentation/router/health_check_router.py
+++ b/src/presentation/router/health_check_router.py
@@ -1,0 +1,25 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from src.presentation.controller.health_check_controller import HealthCheckController
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/health-checks",
+    summary="ヘルスチェック",
+    description="ステータスコード200を返します。",
+    response_description="ヘルスチェックの結果",
+    tags=["Health Check"],
+    responses={
+        200: {
+            "description": "成功時のレスポンス",
+            "content": {"application/json": {"example": {"statusCode": 200}}},
+        }
+    },
+)
+async def check() -> JSONResponse:
+    return HealthCheckController.check()


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/31

# この PR で対応する範囲 / この PR で対応しない範囲

**この PR で対応する範囲：**
- GET /health-checks エンドポイントの追加
- ステータスコード200を返すレスポンスの実装

**この PR で対応しない範囲：**
- なし

# 変更点概要

ECSで起動する際にヘルスチェックが必要となるため、`GET /health-checks` エンドポイントを追加した。
このエンドポイントはステータスコード200と簡易的なレスポンス `{"statusCode": 200}` を返す。

以下のファイルを追加・変更：
- `src/presentation/router/health_check_router.py` - ルーティング定義
- `src/presentation/controller/health_check_controller.py` - コントローラー実装
- `src/main.py` - ルーター登録