### PR TITLE
モジュールインポートパスからsrcを削除

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ packages = ["src"]
 
 [tool.mypy]
 explicit_package_bases = true
-mypy_path = "$MYPY_CONFIG_FILE_DIR"
+mypy_path = "src"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/domain/lgtm_image_object.py
+++ b/src/domain/lgtm_image_object.py
@@ -1,7 +1,7 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 from typing import Required, TypedDict
 
-from src.domain.lgtm_image import LgtmImage, LgtmImageId
+from domain.lgtm_image import LgtmImage, LgtmImageId
 
 
 class LgtmImageObject(TypedDict):

--- a/src/domain/repository/lgtm_image_repository_interface.py
+++ b/src/domain/repository/lgtm_image_repository_interface.py
@@ -2,8 +2,8 @@
 
 from typing import Protocol
 
-from src.domain.lgtm_image import LgtmImageId
-from src.domain.lgtm_image_object import LgtmImageObject
+from domain.lgtm_image import LgtmImageId
+from domain.lgtm_image_object import LgtmImageObject
 
 
 class LgtmImageRepositoryInterface(Protocol):

--- a/src/domain/repository/object_storage_repository_interface.py
+++ b/src/domain/repository/object_storage_repository_interface.py
@@ -2,7 +2,7 @@
 
 from typing import Protocol
 
-from src.domain.create_lgtm_image import UploadObjectStorageDto
+from domain.create_lgtm_image import UploadObjectStorageDto
 
 
 class ObjectStorageRepositoryInterface(Protocol):

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -3,13 +3,13 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.lgtm_image import LgtmImageId
-from src.domain.lgtm_image_object import LgtmImageObject
-from src.domain.repository.lgtm_image_repository_interface import (
+from domain.lgtm_image import LgtmImageId
+from domain.lgtm_image_object import LgtmImageObject
+from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
-from src.infrastructure.models import LgtmImageModel
-from src.log.logger import get_logger
+from infrastructure.models import LgtmImageModel
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/infrastructure/s3_repository.py
+++ b/src/infrastructure/s3_repository.py
@@ -4,11 +4,11 @@ from typing import Any
 
 import aioboto3
 
-from src.domain.repository.object_storage_repository_interface import (
+from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
-from src.domain.create_lgtm_image import UploadObjectStorageDto
-from src.log.logger import get_logger
+from domain.create_lgtm_image import UploadObjectStorageDto
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -4,8 +4,8 @@ import logging
 import os
 from typing import Optional
 
-from src.log.request_id import get_request_id
-from src.log.formatter import JsonFormatter
+from log.request_id import get_request_id
+from log.formatter import JsonFormatter
 
 
 class RequestIdFilter(logging.Filter):

--- a/src/main.py
+++ b/src/main.py
@@ -6,13 +6,13 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from src.presentation.router import health_check_router
-from src.config import get_log_level
-from src.log.logger import setup_logging
-from src.log.request_id import get_request_id
-from src.presentation.middleware.logging_middleware import LoggingMiddleware
-from src.presentation.middleware.request_id_middleware import RequestIdMiddleware
-from src.presentation.router import lgtm_image_router
+from presentation.router import health_check_router
+from config import get_log_level
+from log.logger import setup_logging
+from log.request_id import get_request_id
+from presentation.middleware.logging_middleware import LoggingMiddleware
+from presentation.middleware.request_id_middleware import RequestIdMiddleware
+from presentation.router import lgtm_image_router
 
 # ロギング設定の初期化
 setup_logging(log_level=get_log_level())
@@ -79,7 +79,7 @@ app.include_router(health_check_router.router)
 
 def start() -> None:
     uvicorn.run(
-        "src.main:app",
+        "main:app",
         host="0.0.0.0",
         port=8000,
         reload=True,

--- a/src/presentation/controller/health_check_controller.py
+++ b/src/presentation/controller/health_check_controller.py
@@ -2,7 +2,7 @@
 
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from src.presentation.controller.response_helper import create_json_response
+from presentation.controller.response_helper import create_json_response
 
 
 class HealthCheckResponse(BaseModel):

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -4,30 +4,30 @@ from typing import TYPE_CHECKING
 
 from fastapi.responses import JSONResponse
 
-from src.domain.lgtm_image import LgtmImage
-from src.domain.lgtm_image_errors import ErrInvalidImageExtension, ErrRecordCount
-from src.domain.repository.lgtm_image_repository_interface import (
+from domain.lgtm_image import LgtmImage
+from domain.lgtm_image_errors import ErrInvalidImageExtension, ErrRecordCount
+from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
-from src.log.logger import get_logger
-from src.presentation.controller.lgtm_image_request import LgtmImageCreateRequest
-from src.presentation.controller.lgtm_image_response import (
+from log.logger import get_logger
+from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from presentation.controller.lgtm_image_response import (
     LgtmImageCreateResponse,
     LgtmImageItem,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
 )
-from src.presentation.controller.response_helper import create_json_response
-from src.usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
-from src.usecase.extract_random_lgtm_images_usecase import (
+from presentation.controller.response_helper import create_json_response
+from usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
+from usecase.extract_random_lgtm_images_usecase import (
     ExtractRandomLgtmImagesUsecase,
 )
-from src.usecase.retrieve_recently_created_lgtm_images_usecase import (
+from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
 )
 
 if TYPE_CHECKING:
-    from src.domain.repository.object_storage_repository_interface import (
+    from domain.repository.object_storage_repository_interface import (
         ObjectStorageRepositoryInterface,
     )
 

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from src.domain.create_lgtm_image import can_convert_image_extension
+from domain.create_lgtm_image import can_convert_image_extension
 
 
 class LgtmImageCreateRequest(BaseModel):

--- a/src/presentation/middleware/logging_middleware.py
+++ b/src/presentation/middleware/logging_middleware.py
@@ -6,7 +6,7 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
-from src.log.logger import get_logger
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/presentation/middleware/request_id_middleware.py
+++ b/src/presentation/middleware/request_id_middleware.py
@@ -4,7 +4,7 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
-from src.log.request_id import generate_request_id, set_request_id
+from log.request_id import generate_request_id, set_request_id
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):

--- a/src/presentation/router/health_check_router.py
+++ b/src/presentation/router/health_check_router.py
@@ -2,7 +2,7 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from src.presentation.controller.health_check_controller import HealthCheckController
+from presentation.controller.health_check_controller import HealthCheckController
 
 
 router = APIRouter()

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -6,18 +6,18 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.config import get_lgtm_images_base_url, get_upload_s3_bucket_name
-from src.domain.repository.lgtm_image_repository_interface import (
+from config import get_lgtm_images_base_url, get_upload_s3_bucket_name
+from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
-from src.infrastructure.database import create_db_session
-from src.infrastructure.lgtm_image_repository import LgtmImageRepository
-from src.domain.repository.object_storage_repository_interface import (
+from infrastructure.database import create_db_session
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
-from src.infrastructure.s3_repository import S3Repository
-from src.presentation.controller.lgtm_image_controller import LgtmImageController
-from src.presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from infrastructure.s3_repository import S3Repository
+from presentation.controller.lgtm_image_controller import LgtmImageController
+from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
 
 router = APIRouter()
 

--- a/src/usecase/create_lgtm_image_usecase.py
+++ b/src/usecase/create_lgtm_image_usecase.py
@@ -3,17 +3,17 @@
 import base64
 from datetime import datetime, timezone
 
-from src.domain.create_lgtm_image import (
+from domain.create_lgtm_image import (
     UploadedLgtmImage,
     build_object_prefix,
     create_upload_object_storage_dto,
     create_uploaded_lgtm_image,
     generate_lgtm_image_name,
 )
-from src.domain.repository.object_storage_repository_interface import (
+from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
-from src.log.logger import get_logger
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/usecase/extract_random_lgtm_images_usecase.py
+++ b/src/usecase/extract_random_lgtm_images_usecase.py
@@ -2,13 +2,13 @@
 
 import random
 
-from src.domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT, LgtmImage
-from src.domain.lgtm_image_errors import ErrRecordCount
-from src.domain.lgtm_image_object import create_lgtm_image
-from src.domain.repository.lgtm_image_repository_interface import (
+from domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT, LgtmImage
+from domain.lgtm_image_errors import ErrRecordCount
+from domain.lgtm_image_object import create_lgtm_image
+from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
-from src.log.logger import get_logger
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/usecase/retrieve_recently_created_lgtm_images_usecase.py
+++ b/src/usecase/retrieve_recently_created_lgtm_images_usecase.py
@@ -1,12 +1,12 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
-from src.domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT, LgtmImage
-from src.domain.lgtm_image_errors import ErrRecordCount
-from src.domain.lgtm_image_object import create_lgtm_image
-from src.domain.repository.lgtm_image_repository_interface import (
+from domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT, LgtmImage
+from domain.lgtm_image_errors import ErrRecordCount
+from domain.lgtm_image_object import create_lgtm_image
+from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
-from src.log.logger import get_logger
+from log.logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/tests/domain/test_create_lgtm_image.py
+++ b/tests/domain/test_create_lgtm_image.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from src.domain.create_lgtm_image import (
+from domain.create_lgtm_image import (
     UploadObjectStorageDto,
     UploadedLgtmImage,
     build_object_prefix,

--- a/tests/domain/test_lgtm_image.py
+++ b/tests/domain/test_lgtm_image.py
@@ -1,7 +1,7 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
-from src.domain.lgtm_image import LgtmImage
-from src.domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
+from domain.lgtm_image import LgtmImage
+from domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
 
 
 def test_default_random_images_limit_value() -> None:

--- a/tests/domain/test_lgtm_image_object.py
+++ b/tests/domain/test_lgtm_image_object.py
@@ -1,7 +1,7 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
-from src.domain.lgtm_image import LgtmImageId
-from src.domain.lgtm_image_object import LgtmImageObject, create_lgtm_image
+from domain.lgtm_image import LgtmImageId
+from domain.lgtm_image_object import LgtmImageObject, create_lgtm_image
 
 
 def test_lgtm_image_object_creation() -> None:

--- a/tests/fixtures/test_data_helpers.py
+++ b/tests/fixtures/test_data_helpers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.infrastructure.models import LgtmImageModel
+from infrastructure.models import LgtmImageModel
 
 
 async def insert_test_lgtm_images(

--- a/tests/infrastructure/test_lgtm_image_repository.py
+++ b/tests/infrastructure/test_lgtm_image_repository.py
@@ -5,9 +5,9 @@ from datetime import datetime
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.lgtm_image import LgtmImageId
-from src.infrastructure.lgtm_image_repository import LgtmImageRepository
-from src.infrastructure.models import LgtmImageModel
+from domain.lgtm_image import LgtmImageId
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from infrastructure.models import LgtmImageModel
 
 
 async def insert_test_lgtm_images(

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -10,9 +10,9 @@ from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.infrastructure.lgtm_image_repository import LgtmImageRepository
-from src.presentation.controller.lgtm_image_controller import LgtmImageController
-from src.presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from presentation.controller.lgtm_image_controller import LgtmImageController
+from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images
 
 
@@ -330,7 +330,7 @@ class TestLgtmImageController:
 
         # Act
         with patch(
-            "src.usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
+            "usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
             return_value="test-uuid-789",
         ):
             result = await LgtmImageController.create(
@@ -389,7 +389,7 @@ class TestLgtmImageController:
 
         # Act
         with patch(
-            "src.usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
+            "usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
             return_value="test-uuid-error",
         ):
             result = await LgtmImageController.create(

--- a/tests/usecase/test_create_lgtm_image_usecase.py
+++ b/tests/usecase/test_create_lgtm_image_usecase.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from src.domain.create_lgtm_image import UploadObjectStorageDto
-from src.usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
+from domain.create_lgtm_image import UploadObjectStorageDto
+from usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
 
 
 @pytest.mark.asyncio
@@ -24,7 +24,7 @@ async def test_create_lgtm_image_usecase_success() -> None:
 
     # Act
     with patch(
-        "src.usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
+        "usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
         return_value="test-uuid-123",
     ):
         result = await CreateLgtmImageUsecase.execute(
@@ -66,7 +66,7 @@ async def test_create_lgtm_image_usecase_decodes_base64() -> None:
 
     # Act
     with patch(
-        "src.usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
+        "usecase.create_lgtm_image_usecase.generate_lgtm_image_name",
         return_value="test-uuid-123",
     ):
         result = await CreateLgtmImageUsecase.execute(

--- a/tests/usecase/test_extract_random_lgtm_images_usecase.py
+++ b/tests/usecase/test_extract_random_lgtm_images_usecase.py
@@ -5,10 +5,10 @@ import random
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
-from src.domain.lgtm_image_errors import ErrRecordCount
-from src.infrastructure.lgtm_image_repository import LgtmImageRepository
-from src.usecase.extract_random_lgtm_images_usecase import (
+from domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
+from domain.lgtm_image_errors import ErrRecordCount
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from usecase.extract_random_lgtm_images_usecase import (
     ExtractRandomLgtmImagesUsecase,
 )
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images

--- a/tests/usecase/test_retrieve_recently_created_lgtm_images_usecase.py
+++ b/tests/usecase/test_retrieve_recently_created_lgtm_images_usecase.py
@@ -3,10 +3,10 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
-from src.domain.lgtm_image_errors import ErrRecordCount
-from src.infrastructure.lgtm_image_repository import LgtmImageRepository
-from src.usecase.retrieve_recently_created_lgtm_images_usecase import (
+from domain.lgtm_image import DEFAULT_RANDOM_IMAGES_LIMIT
+from domain.lgtm_image_errors import ErrRecordCount
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
 )
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images
@@ -77,7 +77,7 @@ class TestRetrieveRecentlyCreatedLgtmImagesUsecase:
         """正常系: 結果が作成日時の降順（新しい順）で返される."""
         from datetime import datetime, timedelta, timezone
 
-        from src.infrastructure.models import LgtmImageModel
+        from infrastructure.models import LgtmImageModel
 
         # Arrange - テストデータを異なるcreated_atで挿入
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/33

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- プロジェクト全体のモジュールインポートパスから `src` プレフィックスを削除
- `pyproject.toml` の mypy 設定を調整（`mypy_path` の変更）

## 対応しない範囲
- 特になし

# 変更点概要

プロジェクト構成の変更に伴い、モジュールインポートパスから `src` プレフィックスを削除した。

**変更前:**
```python
from src.domain.lgtm_image import LgtmImageId
```

**変更後:**
```python
from domain.lgtm_image import LgtmImageId
```

この変更により、プロジェクトのモジュール構造がより標準的な形式になり、import 文がシンプルになる。また、`pyproject.toml` の mypy 設定も適切に調整した。
