### PR TITLE
独自CA証明書設定の削除

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -9,7 +9,6 @@ export DATABASE_USER=
 export DATABASE_PASSWORD=
 export DATABASE_HOST=
 export DATABASE_NAME=
-export SSL_CA_CERT=
 
 # PlanetScale API設定（テスト用）
 export PLANETSCALE_ORG_NAME=

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ export DATABASE_USER=
 export DATABASE_PASSWORD=
 export DATABASE_HOST=
 export DATABASE_NAME=
-export SSL_CA_CERT=
 
 # PlanetScale API設定（テスト用）
 export PLANETSCALE_ORG_NAME=

--- a/src/infrastructure/database.py
+++ b/src/infrastructure/database.py
@@ -36,12 +36,7 @@ def get_database_url() -> URL:
 
 
 def get_ssl_context() -> ssl.SSLContext:
-    ssl_ca_cert = os.getenv("SSL_CA_CERT")
-    if not ssl_ca_cert:
-        raise RuntimeError("SSL_CA_CERT environment variable is not set")
-
     ssl_context = ssl.create_default_context()
-    ssl_context.load_verify_locations(cafile=ssl_ca_cert)
     ssl_context.check_hostname = True
 
     return ssl_context


### PR DESCRIPTION
# issueURL

#35

# この PR で対応する範囲 / この PR で対応しない範囲

この PR で対応する範囲：
- 独自CA証明書関連の設定とコードの削除

この PR で対応しない範囲：
- 機能の追加や変更は含まれない（リファクタリングのみ）

# 変更点概要

データベース接続時に使用していた独自CA証明書の設定を削除した。

具体的な変更内容：
1. `SSL_CA_CERT` 環境変数を `.envrc.example` と `README.md` から削除
2. `infrastructure/database.py` の `get_ssl_context()` 関数から独自CA証明書のロード処理を削除
   - `ssl_context.load_verify_locations(cafile=ssl_ca_cert)` の呼び出しを削除
   - `SSL_CA_CERT` 環境変数のチェックとエラーハンドリングを削除

変更後も `ssl.create_default_context()` によるデフォルトのSSL検証は維持されており、セキュリティレベルは保たれている。