### PR TITLE
本番環境・ステージング環境のECS Fargate用設定を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Git
+.git
+.gitignore
+
+# Python generated files
+__pycache__/
+*.py[oc]
+*.pyd
+*.so
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+venv/
+ENV/
+
+# IDE
+.idea
+.vscode
+
+# Environment variables
+.env
+.envrc
+.envrc.example
+
+# Testing and linting caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.tox/
+tests/
+
+# CI/CD
+.github/
+
+# Documentation
+*.md
+!README.md
+
+# Docker files
+Dockerfile
+docker/
+compose.yml
+.dockerignore
+
+# Development tools
+Makefile
+.serena/
+.claude/
+
+# AWS deployment scripts
+task-definition-stg.json
+task-definition-prod.json
+
+# OS
+.DS_Store
+*.swp
+*.swo
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+ARG PYTHON_VERSION=3.12.4
+
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+WORKDIR /src
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml uv.lock README.md ./
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.5 /uv /bin/uv
+
+RUN uv sync --frozen --no-dev --no-install-project
+
+FROM python:${PYTHON_VERSION}-slim
+
+WORKDIR /app
+
+RUN groupadd -r appuser && \
+    useradd -r -g appuser -u 1000 appuser && \
+    chown -R appuser:appuser /app
+
+COPY --from=builder /src/.venv /app/.venv
+
+COPY ./src/ .
+
+RUN chown -R appuser:appuser /app
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+USER appuser
+
+EXPOSE 8000
+
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.29.2-alpine
+
+
+COPY ./docker/nginx/config/default.template /etc/nginx/templates/default.conf.template
+COPY ./docker/nginx/config/nginx.conf /etc/nginx/nginx.conf

--- a/docker/nginx/config/default.template
+++ b/docker/nginx/config/default.template
@@ -1,0 +1,18 @@
+server {
+    listen ${PORT};
+    server_name _;
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log;
+
+    # リクエストサイズの最大値
+    client_max_body_size 6M;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
+    }
+}

--- a/docker/nginx/config/nginx.conf
+++ b/docker/nginx/config/nginx.conf
@@ -1,0 +1,29 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections 4096;
+    multi_accept on;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time $remote_port "$http_x_amzn_trace_id" "$http_x_request_id" "$hostname"';
+
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile on;
+    keepalive_timeout 65;
+    gzip on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/task-definition-prod.json
+++ b/task-definition-prod.json
@@ -1,0 +1,123 @@
+{
+  "family": "prod-lgtm-cat-api-v2",
+  "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-execution-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": true,
+      "environment": [
+        {
+          "name": "ENV",
+          "value": "prod"
+        },
+        {
+          "name": "LGTM_IMAGES_BASE_URL",
+          "value": "lgtm-images.lgtmeow.com"
+        },
+        {
+          "name": "REGION",
+          "value": "ap-northeast-1"
+        },
+        {
+          "name": "UPLOAD_S3_BUCKET_NAME",
+          "value": "prod-lgtmeow-upload-images"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DATABASE_HOST",
+          "valueFrom": "/prod/lgtm-cat/api/DB_HOSTNAME"
+        },
+        {
+          "name": "DATABASE_NAME",
+          "valueFrom": "/prod/lgtm-cat/api/DB_NAME"
+        },
+        {
+          "name": "DATABASE_PASSWORD",
+          "valueFrom": "/prod/lgtm-cat/api/DB_PASSWORD"
+        },
+        {
+          "name": "DATABASE_USER",
+          "valueFrom": "/prod/lgtm-cat/api/DB_USERNAME"
+        }
+      ],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "prod-lgtm-cat-api-app",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "nginx",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "80"
+        },
+        {
+          "name": "BACKEND_HOST",
+          "value": "127.0.0.1"
+        },
+        {
+          "name": "BACKEND_PORT",
+          "value": "8000"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "prod-lgtm-cat-api-nginx",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -1,0 +1,123 @@
+{
+  "family": "stg-lgtm-cat-api-v2",
+  "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-execution-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": true,
+      "environment": [
+        {
+          "name": "ENV",
+          "value": "stg"
+        },
+        {
+          "name": "LGTM_IMAGES_BASE_URL",
+          "value": "stg-lgtm-images.lgtmeow.com"
+        },
+        {
+          "name": "REGION",
+          "value": "ap-northeast-1"
+        },
+        {
+          "name": "UPLOAD_S3_BUCKET_NAME",
+          "value": "stg-lgtmeow-upload-images"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DATABASE_HOST",
+          "valueFrom": "/stg/lgtm-cat/api/DB_HOSTNAME"
+        },
+        {
+          "name": "DATABASE_NAME",
+          "valueFrom": "/stg/lgtm-cat/api/DB_NAME"
+        },
+        {
+          "name": "DATABASE_PASSWORD",
+          "valueFrom": "/stg/lgtm-cat/api/DB_PASSWORD"
+        },
+        {
+          "name": "DATABASE_USER",
+          "valueFrom": "/stg/lgtm-cat/api/DB_USERNAME"
+        }
+      ],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "stg-lgtm-cat-api-app",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "nginx",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "80"
+        },
+        {
+          "name": "BACKEND_HOST",
+          "value": "127.0.0.1"
+        },
+        {
+          "name": "BACKEND_PORT",
+          "value": "8000"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "stg-lgtm-cat-api-nginx",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# issueURL

#37

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- 本番環境用のDockerfile、Nginx設定、ECSタスク定義の追加
- ステージング環境用のECSタスク定義の追加
- .dockerignoreファイルの追加

**対応しない範囲:**
- CDパイプラインの構築は #38 で対応

# 変更点概要

ECS Fargateへのデプロイに必要な設定ファイルを追加した。

- **Dockerfile**: Python 3.12.4-slimベースでuvを利用したマルチステージビルド
- **Nginx設定**: リバースプロキシとして動作し、リクエストサイズ制限を6MBに設定（既存APIと同じ設定）
- **ECSタスク定義**: ステージング環境と本番環境それぞれのタスク定義（ARM64アーキテクチャ、256CPU/512MBメモリ）
- **.dockerignore**: ビルド時に不要なファイルを除外

各環境の設定は環境変数とParameter Storeのシークレットで管理している。

# 補足
Python版のECSの設定は https://github.com/nekochans/lgtm-cat-terraform/pull/128 で対応。