### PR TITLE
LgtmImageObjectのURLに拡張子を追加

### DIFF
--- a/src/domain/lgtm_image_object.py
+++ b/src/domain/lgtm_image_object.py
@@ -13,5 +13,5 @@ class LgtmImageObject(TypedDict):
 def create_lgtm_image(lgtm_image_object: LgtmImageObject, base_url: str) -> LgtmImage:
     return LgtmImage(
         id=str(lgtm_image_object["id"]),
-        url=f"https://{base_url}/{lgtm_image_object['path']}/{lgtm_image_object['filename']}",
+        url=f"https://{base_url}/{lgtm_image_object['path']}/{lgtm_image_object['filename']}.webp",
     )

--- a/tests/domain/test_lgtm_image_object.py
+++ b/tests/domain/test_lgtm_image_object.py
@@ -10,13 +10,13 @@ def test_lgtm_image_object_creation() -> None:
     image_obj = LgtmImageObject(
         id=LgtmImageId(1),
         path="2021/03/16/23",
-        filename="5947f291-a46e-453c-a230-0d756d7174cb.webp",
+        filename="5947f291-a46e-453c-a230-0d756d7174cb",
     )
 
     # Assert
     assert image_obj["id"] == LgtmImageId(1)
     assert image_obj["path"] == "2021/03/16/23"
-    assert image_obj["filename"] == "5947f291-a46e-453c-a230-0d756d7174cb.webp"
+    assert image_obj["filename"] == "5947f291-a46e-453c-a230-0d756d7174cb"
 
 
 def test_lgtm_image_object_equality() -> None:
@@ -25,17 +25,17 @@ def test_lgtm_image_object_equality() -> None:
     image_obj1 = LgtmImageObject(
         id=LgtmImageId(1),
         path="2021/03/16/23",
-        filename="test.webp",
+        filename="test",
     )
     image_obj2 = LgtmImageObject(
         id=LgtmImageId(1),
         path="2021/03/16/23",
-        filename="test.webp",
+        filename="test",
     )
     image_obj3 = LgtmImageObject(
         id=LgtmImageId(2),
         path="2021/03/16/23",
-        filename="test.webp",
+        filename="test",
     )
 
     # Act & Assert
@@ -49,7 +49,7 @@ def test_to_lgtm_image_conversion() -> None:
     image_obj = LgtmImageObject(
         id=LgtmImageId(1),
         path="2021/03/16/23",
-        filename="5947f291-a46e-453c-a230-0d756d7174cb.webp",
+        filename="5947f291-a46e-453c-a230-0d756d7174cb",
     )
     base_url = "lgtm-images.lgtmeow.com"
 
@@ -70,7 +70,7 @@ def test_to_lgtm_image_url_format() -> None:
     image_obj = LgtmImageObject(
         id=LgtmImageId(123),
         path="2024/12/31/10",
-        filename="test-image.webp",
+        filename="test-image",
     )
     base_url = "lgtm-images.lgtmeow.com"
 


### PR DESCRIPTION
<!-- (Copilot Review への依頼: レビューコメントは日本語で記載してください -->

# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/44

# この PR で対応する範囲 / この PR で対応しない範囲

この PR では、LgtmImageObject の URL 生成ロジックに拡張子(.webp)を追加する対応を行う。

対応すする範囲:
- `create_lgtm_image` 関数での URL 生成時に拡張子を追加
- テストコードにおける filename の扱いを変更(拡張子を含まない形式に統一)

この PR で対応しない範囲:
- 特になし

# 変更点概要

`LgtmImageObject` から `LgtmImage` への変換時に、URL 末尾に `.webp` 拡張子を明示的に付与するように変更した。

変更ファイル:
- `src/domain/lgtm_image_object.py` - URL 生成ロジックに `.webp` を追加
- `tests/domain/test_lgtm_image_object.py` - テストデータの `filename` から拡張子を削除

# 補足
STG環境にデプロイし、ローカルのフロントエンドからエンドポイント( POST /lgtm-images、GET /lgtm-images、GET /lgtm-images/recently-created）の操作を行い、正しく動作することを確認。