### PR TITLE
デプロイ先を通常リソース（非v2）に切り替える

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   ENV: prod
-  ECR_REPOSITORY_NGINX: prod-lgtm-cat-api-v2-nginx
-  ECR_REPOSITORY_APP: prod-lgtm-cat-api-v2-app
+  ECR_REPOSITORY_NGINX: prod-lgtm-cat-api-nginx
+  ECR_REPOSITORY_APP: prod-lgtm-cat-api-app
 
 jobs:
   build:
@@ -88,7 +88,7 @@ jobs:
         with:
           task-definition: ${{ steps.task-def-app.outputs.task-definition }}
           wait-for-service-stability: true
-          service: ${{ env.ENV }}-lgtm-cat-api-v2
+          service: ${{ env.ENV }}-lgtm-cat-api
           cluster: ${{ env.ENV }}-lgtm-cat-api
 
       - name: Set release version

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   ENV: stg
-  ECR_REPOSITORY_NGINX: stg-lgtm-cat-api-v2-nginx
-  ECR_REPOSITORY_APP: stg-lgtm-cat-api-v2-app
+  ECR_REPOSITORY_NGINX: stg-lgtm-cat-api-nginx
+  ECR_REPOSITORY_APP: stg-lgtm-cat-api-app
 
 jobs:
   build:
@@ -88,7 +88,7 @@ jobs:
         with:
           task-definition: ${{ steps.task-def-app.outputs.task-definition }}
           wait-for-service-stability: true
-          service: ${{ env.ENV }}-lgtm-cat-api-v2
+          service: ${{ env.ENV }}-lgtm-cat-api
           cluster: ${{ env.ENV }}-lgtm-cat-api
 
       - name: Set release version

--- a/task-definition-prod.json
+++ b/task-definition-prod.json
@@ -1,5 +1,5 @@
 {
-  "family": "prod-lgtm-cat-api-v2",
+  "family": "prod-lgtm-cat-api",
   "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-role",
   "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-execution-role",
   "networkMode": "awsvpc",

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -1,5 +1,5 @@
 {
-  "family": "stg-lgtm-cat-api-v2",
+  "family": "stg-lgtm-cat-api",
   "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-role",
   "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-execution-role",
   "networkMode": "awsvpc",


### PR DESCRIPTION
# issueURL

#47

# この PR で対応する範囲 / この PR で対応しない範囲

この PR では、ECS デプロイ先リソース名を v2 サフィックス付きから通常リソース名に変更する。

対応範囲:
- GitHub Actions ワークフロー（deploy-prod.yml、deploy-stg.yml）の ECR リポジトリ名とサービス名の変更
- ECS タスク定義（task-definition-prod.json、task-definition-stg.json）のファミリー名の変更

# 背景
Go版からPython版への移行のためにv2リソースを作成していた。当初はGo版のリソースを削除し、v2リソースを本番用として残す計画だったが、方針を変更し、Go版で利用していた非v2リソースにPython版をデプロイする形とした。これに伴い、移行用のv2リソースは不要となり削除する。また、デプロイ先も非v2リソースへ変更する必要があり、このPRで対応する。

# 変更点概要

以下のリソース名から `-v2` サフィックスを削除し、通常のリソース名に変更した。
これにより、移行用の一時リソースが削除可能となる。

**本番環境（prod）:**
- ECR リポジトリ: `prod-lgtm-cat-api-v2-nginx` → `prod-lgtm-cat-api-nginx`
- ECR リポジトリ: `prod-lgtm-cat-api-v2-app` → `prod-lgtm-cat-api-app`
- ECS サービス: `prod-lgtm-cat-api-v2` → `prod-lgtm-cat-api`
- タスク定義ファミリー: `prod-lgtm-cat-api-v2` → `prod-lgtm-cat-api`

**ステージング環境（stg）:**
- ECR リポジトリ: `stg-lgtm-cat-api-v2-nginx` → `stg-lgtm-cat-api-nginx`
- ECR リポジトリ: `stg-lgtm-cat-api-v2-app` → `stg-lgtm-cat-api-app`
- ECS サービス: `stg-lgtm-cat-api-v2` → `stg-lgtm-cat-api`
- タスク定義ファミリー: `stg-lgtm-cat-api-v2` → `stg-lgtm-cat-api`

これにより、インフラ側で用意されている通常リソースへのデプロイが可能になる。

# 補足
このPRの対応をすることによって、Terraform側で以下の変更が実行可能になる。
https://github.com/nekochans/lgtm-cat-terraform/pull/135