### PR TITLE
署名付きURLからLGTM画像を作成するユースケース層を実装

### DIFF
--- a/src/infrastructure/repository/http_image_fetch_repository.py
+++ b/src/infrastructure/repository/http_image_fetch_repository.py
@@ -2,7 +2,6 @@
 
 import aiohttp
 from magika import Magika
-from urllib.parse import urlsplit, urlunsplit
 
 from domain.image_format import ALLOWED_IMAGE_MIME_TYPES
 from domain.lgtm_image_errors import (
@@ -16,15 +15,9 @@ from domain.repository.image_fetch_repository_interface import (
 )
 from infrastructure.validator.url_validator import validate_allowed_domain
 from log.logger import get_logger
+from log.url_sanitizer import sanitize_url_for_logging
 
 logger = get_logger(__name__)
-
-
-def _sanitize_url_for_logging(url: str) -> str:
-    parsed = urlsplit(url)
-    # クエリ文字列とフラグメントを空にして再構築
-    sanitized = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
-    return sanitized
 
 
 class HttpImageFetchRepository(ImageFetchRepositoryInterface):
@@ -36,7 +29,7 @@ class HttpImageFetchRepository(ImageFetchRepositoryInterface):
 
     async def fetch_image(self, url: str) -> FetchedImage:
         # クエリパラメータを除去したログ出力用URL（機密情報保護）
-        sanitized_url = _sanitize_url_for_logging(url)
+        sanitized_url = sanitize_url_for_logging(url)
 
         # SSRF対策のURL検証(許可されたドメインのみ許可)
         try:
@@ -58,7 +51,7 @@ class HttpImageFetchRepository(ImageFetchRepositoryInterface):
                     if 300 <= response.status < 400:
                         redirect_url = response.headers.get("Location")
                         sanitized_redirect = (
-                            _sanitize_url_for_logging(redirect_url)
+                            sanitize_url_for_logging(redirect_url)
                             if redirect_url
                             else "(no location)"
                         )

--- a/src/log/url_sanitizer.py
+++ b/src/log/url_sanitizer.py
@@ -1,0 +1,45 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+"""ログ用URL サニタイゼーション機能."""
+
+from urllib.parse import urlsplit, urlunsplit
+
+
+def sanitize_url_for_logging(url: str) -> str:
+    """
+    URLから機密情報(認証情報、クエリパラメータ、フラグメント)を除去してログ用に安全な形式にする.
+
+    Args:
+        url: サニタイズ対象のURL
+
+    Returns:
+        スキーム、ホスト名、パスのみを含む安全なURL文字列
+        入力が不正な場合は空文字列を返す
+    """
+    # 入力検証: Noneまたは空文字列の場合は空文字列を返す
+    if not url:
+        return ""
+
+    try:
+        parsed = urlsplit(url)
+
+        # 認証情報を除去したnetlocを再構築
+        # hostname と port のみを使用し、username と password を除外
+        hostname = parsed.hostname or ""
+        # IPv6 addresses must be wrapped in brackets
+        if ":" in hostname:  # IPv6 address detected
+            if parsed.port:
+                clean_netloc = f"[{hostname}]:{parsed.port}"
+            else:
+                clean_netloc = f"[{hostname}]"
+        elif parsed.port:
+            clean_netloc = f"{hostname}:{parsed.port}"
+        else:
+            clean_netloc = hostname
+
+        # クエリ文字列とフラグメントを空にし、認証情報を除去して再構築
+        sanitized = urlunsplit((parsed.scheme, clean_netloc, parsed.path, "", ""))
+        return sanitized
+
+    except (ValueError, AttributeError):
+        # 不正なURL形式の場合は空文字列を返す
+        return ""

--- a/src/usecase/create_lgtm_image_from_url_usecase.py
+++ b/src/usecase/create_lgtm_image_from_url_usecase.py
@@ -17,6 +17,7 @@ from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
 from log.logger import get_logger
+from log.url_sanitizer import sanitize_url_for_logging
 
 logger = get_logger(__name__)
 
@@ -29,9 +30,12 @@ class CreateLgtmImageFromUrlUseCase:
         base_url: str,
         image_url: str,
     ) -> UploadedLgtmImage:
+        # URLをサニタイズ（クエリパラメータやトークンを除去）
+        safe_url = sanitize_url_for_logging(image_url)
+
         logger.info(
             "Executing CreateLgtmImageFromUrlUseCase",
-            extra={"image_url": image_url},
+            extra={"image_url": safe_url},
         )
 
         # 外部URLから画像を取得（MIMEタイプも含む）
@@ -40,7 +44,7 @@ class CreateLgtmImageFromUrlUseCase:
         logger.info(
             f"Successfully fetched image from URL ({len(fetched_image['data'])} bytes, type: {fetched_image['mime_type']})",
             extra={
-                "image_url": image_url,
+                "image_url": safe_url,
                 "size": len(fetched_image["data"]),
                 "mime_type": fetched_image["mime_type"],
             },

--- a/src/usecase/create_lgtm_image_from_url_usecase.py
+++ b/src/usecase/create_lgtm_image_from_url_usecase.py
@@ -1,0 +1,80 @@
+# 絶対厳守:編集前に必ずAI実装ルールを読む
+
+from datetime import datetime, timezone
+
+from domain.create_lgtm_image import (
+    UploadedLgtmImage,
+    build_object_prefix,
+    create_upload_object_storage_dto,
+    create_uploaded_lgtm_image,
+    generate_lgtm_image_name,
+)
+from domain.image_format import mime_type_to_extension
+from domain.repository.image_fetch_repository_interface import (
+    ImageFetchRepositoryInterface,
+)
+from domain.repository.object_storage_repository_interface import (
+    ObjectStorageRepositoryInterface,
+)
+from log.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class CreateLgtmImageFromUrlUseCase:
+    @staticmethod
+    async def execute(
+        image_fetch_repository: ImageFetchRepositoryInterface,
+        object_storage_repository: ObjectStorageRepositoryInterface,
+        base_url: str,
+        image_url: str,
+    ) -> UploadedLgtmImage:
+        logger.info(
+            "Executing CreateLgtmImageFromUrlUseCase",
+            extra={"image_url": image_url},
+        )
+
+        # 外部URLから画像を取得（MIMEタイプも含む）
+        fetched_image = await image_fetch_repository.fetch_image(image_url)
+
+        logger.info(
+            f"Successfully fetched image from URL ({len(fetched_image['data'])} bytes, type: {fetched_image['mime_type']})",
+            extra={
+                "image_url": image_url,
+                "size": len(fetched_image["data"]),
+                "mime_type": fetched_image["mime_type"],
+            },
+        )
+
+        # MIMEタイプから拡張子を取得
+        image_extension = mime_type_to_extension(fetched_image["mime_type"])
+
+        # オブジェクトのプレフィックスを生成（現在時刻をUTCで取得）
+        now_utc = datetime.now(timezone.utc)
+        prefix = build_object_prefix(now_utc)
+
+        # 画像名を生成
+        image_name = generate_lgtm_image_name()
+
+        # アップロードパラメータを作成
+        upload_param = create_upload_object_storage_dto(
+            body=fetched_image["data"],
+            prefix=prefix,
+            image_name=image_name,
+            image_extension=image_extension,
+        )
+
+        # アップロード
+        await object_storage_repository.upload(upload_param)
+
+        # アップロード済み画像エンティティを作成
+        uploaded_image = create_uploaded_lgtm_image(
+            domain=base_url, prefix=prefix, image_name=image_name
+        )
+
+        logger.info(
+            "CreateLgtmImageFromUrlUseCase completed successfully",
+            extra={"image_url": uploaded_image["url"]},
+        )
+
+        return uploaded_image

--- a/tests/domain/test_image_format.py
+++ b/tests/domain/test_image_format.py
@@ -1,0 +1,73 @@
+# 絶対厳守:編集前に必ずAI実装ルールを読む
+
+import pytest
+
+from domain.image_format import mime_type_to_extension
+from domain.lgtm_image_errors import ErrInvalidImageExtension
+
+
+class TestMimeTypeToExtension:
+    def test_convert_png_mime_type(self) -> None:
+        """image/pngを.pngに変換する."""
+        # Act
+        result = mime_type_to_extension("image/png")
+
+        # Assert
+        assert result == ".png"
+
+    def test_convert_jpeg_mime_type(self) -> None:
+        """image/jpegを.jpgに変換する."""
+        # Act
+        result = mime_type_to_extension("image/jpeg")
+
+        # Assert
+        assert result == ".jpg"
+
+    def test_raises_error_for_unsupported_mime_type(self) -> None:
+        """サポートされていないMIMEタイプの場合、エラーを発生させる."""
+        # Act & Assert
+        with pytest.raises(ErrInvalidImageExtension) as exc_info:
+            mime_type_to_extension("image/webp")
+
+        assert "Unsupported MIME type" in str(exc_info.value)
+        assert "image/webp" in str(exc_info.value)
+
+    def test_raises_error_for_invalid_mime_type(self) -> None:
+        """無効なMIMEタイプの場合、エラーを発生させる."""
+        # Act & Assert
+        with pytest.raises(ErrInvalidImageExtension) as exc_info:
+            mime_type_to_extension("application/pdf")
+
+        assert "Unsupported MIME type" in str(exc_info.value)
+
+    def test_convert_uppercase_mime_type(self) -> None:
+        """大文字のMIMEタイプも正しく変換される(大文字小文字を区別しない)."""
+        # Act
+        result = mime_type_to_extension("IMAGE/JPEG")
+
+        # Assert
+        assert result == ".jpg"
+
+    def test_convert_mixed_case_mime_type(self) -> None:
+        """混在した大文字小文字のMIMEタイプも正しく変換される."""
+        # Act
+        result = mime_type_to_extension("Image/Png")
+
+        # Assert
+        assert result == ".png"
+
+    def test_convert_mime_type_with_whitespace(self) -> None:
+        """前後に空白を含むMIMEタイプも正しく変換される(トリム処理)."""
+        # Act
+        result = mime_type_to_extension("  image/jpeg  ")
+
+        # Assert
+        assert result == ".jpg"
+
+    def test_convert_mime_type_uppercase_with_whitespace(self) -> None:
+        """大文字と空白の両方を含むMIMEタイプも正しく変換される."""
+        # Act
+        result = mime_type_to_extension("  IMAGE/PNG  ")
+
+        # Assert
+        assert result == ".png"

--- a/tests/usecase/test_create_lgtm_image_from_url_usecase.py
+++ b/tests/usecase/test_create_lgtm_image_from_url_usecase.py
@@ -1,0 +1,152 @@
+"""CreateLgtmImageFromUrlUseCaseのテスト."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.lgtm_image_errors import (
+    ErrImageFetchFailed,
+    ErrInvalidImageExtension,
+    ErrInvalidUrl,
+)
+from usecase.create_lgtm_image_from_url_usecase import CreateLgtmImageFromUrlUseCase
+
+
+class TestCreateLgtmImageFromUrlUseCase:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "image_url,image_data,mime_type,expected_extension",
+        [
+            (
+                "https://example.com/image.png",
+                b"\x89PNG\r\n\x1a\n" + b"\x00" * 100,
+                "image/png",
+                ".png",
+            ),
+            (
+                "https://example.com/image.jpg",
+                b"\xff\xd8\xff" + b"\x00" * 100,
+                "image/jpeg",
+                ".jpg",
+            ),
+        ],
+    )
+    async def test_execute_success(
+        self,
+        image_url: str,
+        image_data: bytes,
+        mime_type: str,
+        expected_extension: str,
+    ) -> None:
+        """正常系: 画像の取得とアップロードに成功する."""
+        # Arrange
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": image_data, "mime_type": mime_type}
+        )
+
+        mock_storage_repo = AsyncMock()
+        mock_storage_repo.upload = AsyncMock()
+
+        # Act
+        result = await CreateLgtmImageFromUrlUseCase.execute(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            image_url=image_url,
+        )
+
+        # Assert
+        assert isinstance(result, dict)
+        assert "url" in result
+        assert result["url"].startswith(f"https://{base_url}/")
+        assert result["url"].endswith(".webp")
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_storage_repo.upload.assert_called_once()
+
+        # uploadに渡されたパラメータを確認
+        upload_call_args = mock_storage_repo.upload.call_args[0][0]
+        assert upload_call_args["body"] == image_data
+        assert upload_call_args["image_extension"] == expected_extension
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_error_when_image_fetch_fails(self) -> None:
+        """異常系: 画像取得に失敗した場合、エラーを発生させる."""
+        # Arrange
+        image_url = "https://example.com/image.jpg"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrImageFetchFailed("Failed to fetch")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        # Act & Assert
+        with pytest.raises(ErrImageFetchFailed):
+            await CreateLgtmImageFromUrlUseCase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                object_storage_repository=mock_storage_repo,
+                base_url=base_url,
+                image_url=image_url,
+            )
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_error_when_invalid_url(self) -> None:
+        """異常系: 無効なURLの場合、エラーを発生させる."""
+        # Arrange
+        image_url = "http://localhost/image.jpg"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrInvalidUrl("Invalid URL")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        # Act & Assert
+        with pytest.raises(ErrInvalidUrl):
+            await CreateLgtmImageFromUrlUseCase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                object_storage_repository=mock_storage_repo,
+                base_url=base_url,
+                image_url=image_url,
+            )
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_error_when_unsupported_format(self) -> None:
+        """異常系: サポートされていない画像形式の場合、エラーを発生させる."""
+        # Arrange
+        image_url = "https://example.com/image.webp"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        # WebPのマジックナンバー
+        webp_data = b"RIFF" + b"\x00" * 4 + b"WEBP" + b"\x00" * 100
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": webp_data, "mime_type": "image/webp"}
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        # Act & Assert
+        with pytest.raises(ErrInvalidImageExtension) as exc_info:
+            await CreateLgtmImageFromUrlUseCase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                object_storage_repository=mock_storage_repo,
+                base_url=base_url,
+                image_url=image_url,
+            )
+
+        assert "Unsupported MIME type" in str(exc_info.value)
+        mock_storage_repo.upload.assert_not_called()


### PR DESCRIPTION
<!-- (Copilot Review への依頼: レビューコメントは日本語で記載してください -->

# issueURL

#30

# この PR で対応する範囲 / この PR で対応しない範囲

## この PR で対応する範囲

- 署名付きURLから画像を取得するユースケース層の実装
- URLサニタイゼーション機能の共通モジュール化
- ドメイン層のMIMEタイプ変換機能へのテスト追加

## この PR で対応しない範囲

- プレゼンテーション層の実装（新しいエンドポイント `/v2/lgtm-images` の追加）は別PRで対応する

# 変更点概要

署名付きURLから画像を取得してLGTM画像を作成する機能のユースケース層を実装した。

主な変更点は以下である：

1. **URLサニタイゼーション機能の共通化**: クエリパラメータを除去する処理を`log/url_sanitizer.py`として独立したモジュールに切り出し、再利用可能にした

2. **ユースケース層の実装**: `CreateLgtmImageFromUrlUseCase`を実装し、画像取得リポジトリとオブジェクトストレージリポジトリを組み合わせた処理フローを定義した

3. **ドメイン層のテスト拡充**: MIMEタイプから拡張子への変換機能に対するテストケースを追加し、サポート対象外の形式（GIF等）の検証を強化した

この実装により、外部URLから画像を取得してLGTM画像として保存する機能の中核的なビジネスロジックが完成した。