### PR TITLE
署名付きURLからの画像取得機能をプレゼンテーション層に実装

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -29,6 +29,9 @@ export COGNITO_REGION=ap-northeast-1
 export COGNITO_USER_POOL_ID=
 export COGNITO_APP_CLIENT_ID=
 
+# 画像取得設定（URL画像取得機能用）
+export IMAGE_ALLOWED_DOMAIN=
+
 # Sentry設定（エラー監視）
 export SENTRY_DSN=
 export SENTRY_ENVIRONMENT=

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ export COGNITO_REGION=ap-northeast-1
 export COGNITO_USER_POOL_ID=
 export COGNITO_APP_CLIENT_ID=
 
+# 画像取得設定（URL画像取得機能用）
+export IMAGE_ALLOWED_DOMAIN=  # アクセス可能なドメイン（例: example.r2.cloudflarestorage.com）
+
 # Sentry設定（エラー監視）
 export SENTRY_DSN=           # SentryのDSN（未設定時はSentry無効）
 export SENTRY_ENVIRONMENT=   # 実行環境名

--- a/src/config.py
+++ b/src/config.py
@@ -24,10 +24,12 @@ SENTRY_ENVIRONMENT: Final[str] = os.getenv("SENTRY_ENVIRONMENT", "development")
 # 必須の環境変数（Noneを許可するが、起動時に検証が必要）
 _cognito_user_pool_id: Optional[str] = os.getenv("COGNITO_USER_POOL_ID")
 _cognito_app_client_id: Optional[str] = os.getenv("COGNITO_APP_CLIENT_ID")
+_image_allowed_domain: Optional[str] = os.getenv("IMAGE_ALLOWED_DOMAIN")
 
 # NOTE: これらの定数は validate_required_config() が成功した後のみ安全にアクセス可能
 COGNITO_USER_POOL_ID: Final[str] = _cognito_user_pool_id or ""
 COGNITO_APP_CLIENT_ID: Final[str] = _cognito_app_client_id or ""
+IMAGE_ALLOWED_DOMAIN: Final[str] = _image_allowed_domain or ""
 
 
 def validate_required_config() -> None:
@@ -38,6 +40,9 @@ def validate_required_config() -> None:
 
     if not _cognito_app_client_id:
         missing_vars.append("COGNITO_APP_CLIENT_ID")
+
+    if not _image_allowed_domain:
+        missing_vars.append("IMAGE_ALLOWED_DOMAIN")
 
     if missing_vars:
         error_msg = (
@@ -76,3 +81,23 @@ def get_sentry_dsn() -> str:
 
 def get_sentry_environment() -> str:
     return SENTRY_ENVIRONMENT
+
+
+# 画像取得設定
+# HTTPリクエストのタイムアウト（秒）
+IMAGE_FETCH_TIMEOUT: Final[int] = 5
+
+# 画像の最大サイズ（バイト）デフォルト: 4MB
+MAX_IMAGE_SIZE: Final[int] = 4 * 1024 * 1024
+
+
+def get_image_fetch_timeout() -> int:
+    return IMAGE_FETCH_TIMEOUT
+
+
+def get_max_image_size() -> int:
+    return MAX_IMAGE_SIZE
+
+
+def get_image_allowed_domain() -> str:
+    return IMAGE_ALLOWED_DOMAIN

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ from log.logger import setup_logging
 from log.request_id import get_request_id
 from presentation.middleware.logging_middleware import LoggingMiddleware
 from presentation.middleware.request_id_middleware import RequestIdMiddleware
-from presentation.router import lgtm_image_router
+from presentation.router import lgtm_image_router, lgtm_image_v2_router
 
 # 必須の環境変数を検証（起動時にfail-fast）
 try:
@@ -103,6 +103,7 @@ app.add_middleware(RequestIdMiddleware)
 
 # ルーターの登録
 app.include_router(lgtm_image_router.router)
+app.include_router(lgtm_image_v2_router.router)
 app.include_router(health_check_router.router)
 
 

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -16,6 +16,7 @@ from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
 from log.logger import get_logger
+from log.url_sanitizer import sanitize_url_for_logging
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
@@ -87,9 +88,10 @@ class LgtmImageController:
         base_url: str,
         request_body: LgtmImageCreateFromUrlRequest,
     ) -> JSONResponse:
+        sanitized_url = sanitize_url_for_logging(request_body.image_url)
         logger.info(
             "Creating LGTM image from URL",
-            extra={"image_url": request_body.image_url},
+            extra={"image_url": sanitized_url},
         )
 
         try:

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -5,12 +5,21 @@ from typing import TYPE_CHECKING
 from fastapi.responses import JSONResponse
 
 from domain.lgtm_image import LgtmImage
-from domain.lgtm_image_errors import ErrInvalidImageExtension, ErrRecordCount
+from domain.lgtm_image_errors import (
+    ErrImageFetchFailed,
+    ErrInvalidImageExtension,
+    ErrInvalidUrl,
+    ErrRecordCount,
+    ErrUrlNotAccessible,
+)
 from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
 from log.logger import get_logger
-from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from presentation.controller.lgtm_image_request import (
+    LgtmImageCreateFromUrlRequest,
+    LgtmImageCreateRequest,
+)
 from presentation.controller.lgtm_image_response import (
     LgtmImageCreateResponse,
     LgtmImageItem,
@@ -21,6 +30,9 @@ from presentation.controller.response_helper import (
     create_json_response,
     create_error_response,
 )
+from usecase.create_lgtm_image_from_url_usecase import (
+    CreateLgtmImageFromUrlUseCase,
+)
 from usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
 from usecase.extract_random_lgtm_images_usecase import (
     ExtractRandomLgtmImagesUsecase,
@@ -30,6 +42,9 @@ from usecase.retrieve_recently_created_lgtm_images_usecase import (
 )
 
 if TYPE_CHECKING:
+    from domain.repository.image_fetch_repository_interface import (
+        ImageFetchRepositoryInterface,
+    )
     from domain.repository.object_storage_repository_interface import (
         ObjectStorageRepositoryInterface,
     )
@@ -63,6 +78,55 @@ class LgtmImageController:
             )
         except Exception as e:
             logger.error(f"Error creating LGTM image: {e}")
+            return create_error_response(e)
+
+    @staticmethod
+    async def create_from_url(
+        image_fetch_repository: "ImageFetchRepositoryInterface",
+        object_storage_repository: "ObjectStorageRepositoryInterface",
+        base_url: str,
+        request_body: LgtmImageCreateFromUrlRequest,
+    ) -> JSONResponse:
+        logger.info(
+            "Creating LGTM image from URL",
+            extra={"image_url": request_body.image_url},
+        )
+
+        try:
+            uploaded_image = await CreateLgtmImageFromUrlUseCase.execute(
+                image_fetch_repository=image_fetch_repository,
+                object_storage_repository=object_storage_repository,
+                base_url=base_url,
+                image_url=request_body.image_url,
+            )
+            response = LgtmImageCreateResponse(imageUrl=uploaded_image["url"])  # type: ignore[arg-type]
+            return create_json_response(response, status_code=202)
+        except ErrInvalidUrl as e:
+            logger.error(f"Invalid URL provided: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Invalid URL provided"},
+            )
+        except ErrUrlNotAccessible as e:
+            logger.error(f"URL not accessible: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "URL not accessible"},
+            )
+        except ErrImageFetchFailed as e:
+            logger.error(f"Failed to fetch image: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Failed to fetch image from URL"},
+            )
+        except ErrInvalidImageExtension as e:
+            logger.error(f"Invalid image extension: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Invalid image extension or unsupported format"},
+            )
+        except Exception as e:
+            logger.error(f"Error creating LGTM image from URL: {e}")
             return create_error_response(e)
 
     @staticmethod

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -1,5 +1,7 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
+from urllib.parse import urlparse
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from domain.create_lgtm_image import can_convert_image_extension
@@ -25,4 +27,37 @@ class LgtmImageCreateRequest(BaseModel):
     def validate_image_extension(cls, v: str) -> str:
         if not can_convert_image_extension(v):
             raise ValueError(f"Invalid image extension: {v}")
+        return v
+
+
+class LgtmImageCreateFromUrlRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    image_url: str = Field(
+        ...,
+        alias="imageUrl",
+        description=(
+            "画像のURL（httpsのみ許可）。"
+            "URLの形式・スキームを検証します。"
+            "許可ドメインのチェックは infrastructure 層で実施します。"
+        ),
+        examples=[
+            "https://allowed-bucket.r2.cloudflarestorage.com/image.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+        ],
+        min_length=1,
+    )
+
+    @field_validator("image_url")
+    @classmethod
+    def validate_image_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+
+        # httpsのみ許可
+        if parsed.scheme != "https":
+            raise ValueError("image_url must be https URL")
+
+        # ホスト名が存在することを確認
+        if not parsed.netloc:
+            raise ValueError("image_url must have a valid hostname")
+
         return v

--- a/src/presentation/router/lgtm_image_v2_router.py
+++ b/src/presentation/router/lgtm_image_v2_router.py
@@ -1,0 +1,140 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from config import (
+    get_image_fetch_timeout,
+    get_lgtm_images_base_url,
+    get_max_image_size,
+    get_image_allowed_domain,
+    get_upload_s3_bucket_name,
+)
+from domain.repository.image_fetch_repository_interface import (
+    ImageFetchRepositoryInterface,
+)
+from domain.repository.object_storage_repository_interface import (
+    ObjectStorageRepositoryInterface,
+)
+from infrastructure.repository.http_image_fetch_repository import (
+    HttpImageFetchRepository,
+)
+from infrastructure.s3_repository import S3Repository
+from presentation.controller.lgtm_image_controller import LgtmImageController
+from presentation.controller.lgtm_image_request import (
+    LgtmImageCreateFromUrlRequest,
+)
+from presentation.dependencies.auth import verify_token
+
+router = APIRouter()
+
+
+def create_image_fetch_repository(
+    timeout: int = Depends(get_image_fetch_timeout),
+    max_size: int = Depends(get_max_image_size),
+    allowed_domain: str = Depends(get_image_allowed_domain),
+) -> ImageFetchRepositoryInterface:
+    return HttpImageFetchRepository(
+        timeout=timeout, max_size=max_size, allowed_domain=allowed_domain
+    )
+
+
+def create_object_storage_repository(
+    bucket_name: str = Depends(get_upload_s3_bucket_name),
+) -> ObjectStorageRepositoryInterface:
+    return S3Repository(bucket_name)
+
+
+@router.post(
+    "/v2/lgtm-images",
+    summary="署名付きURLからLGTM画像を作成",
+    description="許可された署名付きURLから画像を取得してS3にアップロードし、URLを返します。セキュリティ上、事前に設定されたドメインのURLのみ受け付けます。",
+    response_description="アップロードされた画像のURL",
+    tags=["LGTM Images V2"],
+    status_code=202,
+    responses={
+        202: {
+            "description": "受理された（アップロード処理中）",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "imageUrl": "https://lgtm-images.lgtmeow.com/2024/01/15/14/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "無効なURLまたは許可されていないドメイン",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "invalid_url": {
+                            "summary": "無効なURL",
+                            "value": {"error": "Invalid URL provided"},
+                        },
+                        "domain_not_allowed": {
+                            "summary": "許可されていないドメイン",
+                            "value": {"error": "URL domain is not allowed"},
+                        },
+                        "url_not_accessible": {
+                            "summary": "URLにアクセスできない",
+                            "value": {"error": "URL not accessible"},
+                        },
+                    }
+                }
+            },
+        },
+        401: {
+            "description": "認証エラー",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid authorization header"}
+                }
+            },
+        },
+        422: {
+            "description": "画像取得失敗または無効な画像形式",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "fetch_failed": {
+                            "summary": "画像取得失敗",
+                            "value": {"error": "Failed to fetch image from URL"},
+                        },
+                        "invalid_format": {
+                            "summary": "無効な画像形式",
+                            "value": {
+                                "error": "invalid image extension or unsupported format"
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        500: {
+            "description": "サーバーエラー",
+            "content": {
+                "application/json": {"example": {"error": "Internal server error"}}
+            },
+        },
+    },
+)
+async def create_lgtm_image_from_url(
+    request_body: LgtmImageCreateFromUrlRequest,
+    image_fetch_repository: Annotated[
+        ImageFetchRepositoryInterface, Depends(create_image_fetch_repository)
+    ],
+    object_storage_repository: Annotated[
+        ObjectStorageRepositoryInterface, Depends(create_object_storage_repository)
+    ],
+    base_url: str = Depends(get_lgtm_images_base_url),
+    token_payload: dict[str, Any] = Depends(verify_token),
+) -> JSONResponse:
+    return await LgtmImageController.create_from_url(
+        image_fetch_repository,
+        object_storage_repository,
+        base_url,
+        request_body,
+    )

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from infrastructure.lgtm_image_repository import LgtmImageRepository
 from presentation.controller.lgtm_image_controller import LgtmImageController
-from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from presentation.controller.lgtm_image_request import (
+    LgtmImageCreateFromUrlRequest,
+    LgtmImageCreateRequest,
+)
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images
 
 
@@ -405,3 +408,225 @@ class TestLgtmImageController:
         content = json.loads(bytes(result.body))
         assert "error" in content
         assert "Internal server error" in content["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_success(self) -> None:
+        """正常系: 許可されたURLから画像を取得してアップロードに成功する."""
+        # Arrange
+        image_url = "https://example.com/image.png"
+        base_url = "lgtm-images.lgtmeow.com"
+        expected_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": expected_data, "mime_type": "image/png"}
+        )
+
+        mock_storage_repo = AsyncMock()
+        mock_storage_repo.upload = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        with patch(
+            "usecase.create_lgtm_image_from_url_usecase.generate_lgtm_image_name",
+            return_value="test-uuid-url",
+        ):
+            result = await LgtmImageController.create_from_url(
+                image_fetch_repository=mock_image_fetch_repo,
+                object_storage_repository=mock_storage_repo,
+                base_url=base_url,
+                request_body=request_body,
+            )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 202
+
+        content = json.loads(bytes(result.body))
+        assert "imageUrl" in content
+        assert base_url in content["imageUrl"]
+        assert "test-uuid-url" in content["imageUrl"]
+        assert content["imageUrl"].endswith(".webp")
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_storage_repo.upload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_invalid_url_error(self) -> None:
+        """異常系: 無効なURLの場合、400エラーを返す."""
+        # Arrange
+        image_url = "https://localhost/image.png"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrInvalidUrl
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrInvalidUrl("Invalid URL")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.create_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            request_body=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Invalid URL provided" in content["error"]
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_not_accessible_error(self) -> None:
+        """異常系: URLにアクセスできない場合、400エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/not-found.png"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrUrlNotAccessible
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrUrlNotAccessible("URL not found")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.create_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            request_body=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "URL not accessible" in content["error"]
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_fetch_failed_error(self) -> None:
+        """異常系: 画像取得失敗の場合、422エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/image.png"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrImageFetchFailed
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrImageFetchFailed("Failed to fetch")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.create_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            request_body=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Failed to fetch image from URL" in content["error"]
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_invalid_extension_error(self) -> None:
+        """異常系: サポートされていない画像形式の場合、422エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/image.gif"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        # GIFのマジックナンバー
+        gif_data = b"GIF89a" + b"\x00" * 100
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": gif_data, "mime_type": "image/gif"}
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.create_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            request_body=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Invalid image extension or unsupported format" in content["error"]
+
+        mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_from_url_general_exception_error(self) -> None:
+        """異常系: 予期しないエラーの場合、500エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/image.png"
+        base_url = "lgtm-images.lgtmeow.com"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=Exception("Unexpected error")
+        )
+
+        mock_storage_repo = AsyncMock()
+
+        request_body = LgtmImageCreateFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.create_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            object_storage_repository=mock_storage_repo,
+            base_url=base_url,
+            request_body=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Internal server error" in content["error"]
+
+        mock_storage_repo.upload.assert_not_called()

--- a/tests/presentation/controller/test_lgtm_image_request.py
+++ b/tests/presentation/controller/test_lgtm_image_request.py
@@ -1,0 +1,104 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+"""LgtmImageCreateFromUrlRequestのバリデーションテスト."""
+
+import pytest
+from pydantic import ValidationError
+
+from presentation.controller.lgtm_image_request import (
+    LgtmImageCreateFromUrlRequest,
+)
+
+
+class TestLgtmImageCreateFromUrlRequest:
+    def test_valid_https_url(self) -> None:
+        """正常系: 有効なHTTPS URLが受け入れられる."""
+        # Arrange & Act
+        request = LgtmImageCreateFromUrlRequest(
+            imageUrl="https://example.com/image.png"
+        )
+
+        # Assert
+        assert request.image_url == "https://example.com/image.png"
+
+    def test_valid_https_url_with_query_params(self) -> None:
+        """正常系: クエリパラメータ付きのHTTPS URLが受け入れられる."""
+        # Arrange & Act
+        request = LgtmImageCreateFromUrlRequest(
+            imageUrl="https://bucket.s3.amazonaws.com/image.png?AWSAccessKeyId=XXX&Signature=YYY"
+        )
+
+        # Assert
+        assert (
+            request.image_url
+            == "https://bucket.s3.amazonaws.com/image.png?AWSAccessKeyId=XXX&Signature=YYY"
+        )
+
+    def test_valid_https_url_with_path(self) -> None:
+        """正常系: 複雑なパスを持つHTTPS URLが受け入れられる."""
+        # Arrange & Act
+        request = LgtmImageCreateFromUrlRequest(
+            imageUrl="https://cdn.example.com/images/2025/01/test.jpg"
+        )
+
+        # Assert
+        assert request.image_url == "https://cdn.example.com/images/2025/01/test.jpg"
+
+    @pytest.mark.parametrize(
+        "invalid_url,expected_error_msg",
+        [
+            ("http://example.com/image.png", "https URL"),
+            ("ftp://example.com/image.png", "https URL"),
+            ("file:///path/to/image.png", "https URL"),
+            ("example.com/image.png", "https URL"),
+        ],
+        ids=["http-scheme", "ftp-scheme", "file-scheme", "no-scheme"],
+    )
+    def test_invalid_url_schemes(
+        self, invalid_url: str, expected_error_msg: str
+    ) -> None:
+        """異常系: HTTPS以外のスキームのURLは拒否される."""
+        # Arrange & Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            LgtmImageCreateFromUrlRequest(imageUrl=invalid_url)
+
+        # バリデーションエラーの詳細を確認
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("imageUrl",)
+        assert expected_error_msg in str(errors[0]["msg"])
+
+    def test_invalid_no_hostname(self) -> None:
+        """異常系: ホスト名のないURLは拒否される."""
+        # Arrange & Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            LgtmImageCreateFromUrlRequest(imageUrl="https://")
+
+        # バリデーションエラーの詳細を確認
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("imageUrl",)
+        assert "valid hostname" in str(errors[0]["msg"])
+
+    def test_invalid_not_url_format(self) -> None:
+        """異常系: URL形式ではない文字列は拒否される."""
+        # Arrange & Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            LgtmImageCreateFromUrlRequest(imageUrl="not-a-url")
+
+        # バリデーションエラーの詳細を確認
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("imageUrl",)
+
+    def test_invalid_empty_string(self) -> None:
+        """異常系: 空文字列は拒否される."""
+        # Arrange & Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            LgtmImageCreateFromUrlRequest(imageUrl="")
+
+        # バリデーションエラーの詳細を確認
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("imageUrl",)
+        # min_length=1の制約によってエラーになる
+        assert "at least 1 character" in str(errors[0]["msg"])


### PR DESCRIPTION
# issueURL

#30

# このPRで対応する範囲 / このPRで対応しない範囲

**対応する範囲:**
- プレゼンテーション層での署名付きURL画像取得エンドポイント（`/v2/lgtm-images`）の実装
- `LgtmImageController`への`create_from_url`メソッド追加
- `LgtmImageCreateFromUrlRequest`リクエストモデルの実装とバリデーション
- 新規ルーター`lgtm_image_v2_router.py`の作成と`main.py`への登録
- 環境変数`IMAGE_ALLOWED_DOMAIN`の設定追加とドキュメント更新

**対応しない範囲:**
- ドメイン層とユースケース層、インフラストラクチャ層の実装（既に別PRで実装済み）
- タスクの定義にSecretsを追加（別PRで対応予定）

# 変更点概要

署名付きURLから画像を取得してLGTM画像を作成する機能のプレゼンテーション層を実装しました。

**主な変更点:**
1. 新しいエンドポイント`POST /v2/lgtm-images`を追加
2. URLバリデーション（HTTPS必須、ホスト名必須）をリクエストモデルで実装
3. ドメイン検証、画像取得、形式変換などのエラーを適切なHTTPステータスコードに変換
4. 環境変数`IMAGE_ALLOWED_DOMAIN`の設定追加とREADME/envrc.exampleへの反映
5. プレゼンテーション層のテストコード追加（正常系・異常系）

# レビュアーに重点的にチェックして欲しい点

リクエストバリデーションロジック（`LgtmImageCreateFromUrlRequest`）では基本的なURL形式のバリデーション（HTTPS必須、ホスト名必須）のみを行い、詳細なドメイン検証はinfrastructure層（`HttpImageFetchRepository`）で実施する設計としていますが、この責務分離が適切か確認をお願いします。

**infrastructure層でドメイン検証を行う理由:**
外部リソース（HTTP）へのアクセス制御は、その実装を持つinfrastructure層の責務であり、実際に画像を取得する`HttpImageFetchRepository`がどのドメインから取得可能かを判断する最適な場所と判断した。

# 補足情報

- 本PRはissue #30の3番目のPRです（ドメイン層・ユースケース層・インフラストラクチャ層は別PRで実装済み）
- エンドポイントを`/v2/lgtm-images`とすることで既存のbase64アップロード機能との共存を実現