### PR TITLE
ECS環境でIMAGE_ALLOWED_DOMAIN環境変数を参照できるようタスク定義を更新

### DIFF
--- a/task-definition-prod.json
+++ b/task-definition-prod.json
@@ -73,6 +73,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "/prod/lgtm-cat/api/SENTRY_DSN"
+        },
+        {
+          "name": "IMAGE_ALLOWED_DOMAIN",
+          "valueFrom": "/prod/lgtm-cat/api/IMAGE_ALLOWED_DOMAIN"
         }
       ],
       "ulimits": [

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -73,6 +73,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "/stg/lgtm-cat/api/SENTRY_DSN"
+        },
+        {
+          "name": "IMAGE_ALLOWED_DOMAIN",
+          "valueFrom": "/stg/lgtm-cat/api/IMAGE_ALLOWED_DOMAIN"
         }
       ],
       "ulimits": [


### PR DESCRIPTION
# issueURL

#30

# この PR で対応する範囲 / この PR で対応しない範囲

この PR で対応する範囲:
- 本番環境とステージング環境のECSタスク定義にIMAGE_ALLOWED_DOMAIN環境変数の設定を追加

この PR で対応しない範囲:
- アプリケーションコードの実装（別PRで完了済み）

# 変更点概要

署名付きURLからの画像取得機能が正常に動作するために必要なIMAGE_ALLOWED_DOMAIN環境変数を、
ECS環境でParameter Storeから取得できるよう、本番環境とステージング環境のタスク定義に設定を追加した。

これにより、ECS上で動作するアプリケーションが署名付きURLの検証に必要な許可ドメイン情報を環境変数として取得できるようになる。

# 補足情報

- 環境変数の実際の値はAWS Systems Manager Parameter Storeで管理されている
    - 本番環境: `/prod/lgtm-cat/api/IMAGE_ALLOWED_DOMAIN`
    - ステージング環境: `/stg/lgtm-cat/api/IMAGE_ALLOWED_DOMAIN`
AWS Systems Manager Parameter Storeへの追加は https://github.com/nekochans/lgtm-cat-terraform/issues/144 で対応する。

- このPRで #30 は完了する
