### PR TITLE
FastAPIの依存関数をAnnotated記法に統一

### DIFF
--- a/src/presentation/dependencies/auth.py
+++ b/src/presentation/dependencies/auth.py
@@ -23,9 +23,9 @@ from infrastructure.cognito_token_verifier_repository import (
 
 
 def create_token_verifier_repository(
-    region: str = Depends(get_cognito_region),
-    user_pool_id: str = Depends(get_cognito_user_pool_id),
-    app_client_id: str = Depends(get_cognito_app_client_id),
+    region: Annotated[str, Depends(get_cognito_region)],
+    user_pool_id: Annotated[str, Depends(get_cognito_user_pool_id)],
+    app_client_id: Annotated[str, Depends(get_cognito_app_client_id)],
 ) -> JwtTokenVerifierRepositoryInterface:
     return CognitoTokenVerifierRepository(region, user_pool_id, app_client_id)
 
@@ -34,7 +34,7 @@ async def verify_token(
     token_verifier: Annotated[
         JwtTokenVerifierRepositoryInterface, Depends(create_token_verifier_repository)
     ],
-    authorization: str = Header(..., description="Bearer token"),
+    authorization: Annotated[str, Header(..., description="Bearer token")],
 ) -> dict[str, Any]:
     if not authorization.lower().startswith("bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization header")

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -33,7 +33,7 @@ def create_lgtm_image_repository(
 
 
 def create_object_storage_repository(
-    bucket_name: str = Depends(get_upload_s3_bucket_name),
+    bucket_name: Annotated[str, Depends(get_upload_s3_bucket_name)],
 ) -> ObjectStorageRepositoryInterface:
     return S3Repository(bucket_name)
 
@@ -85,8 +85,8 @@ async def create_lgtm_image(
     object_storage_repository: Annotated[
         ObjectStorageRepositoryInterface, Depends(create_object_storage_repository)
     ],
-    base_url: str = Depends(get_lgtm_images_base_url),
-    token_payload: dict[str, Any] = Depends(verify_token),
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.create(
         object_storage_repository, base_url, request_body
@@ -133,8 +133,8 @@ async def extract_random_lgtm_images(
     repository: Annotated[
         LgtmImageRepositoryInterface, Depends(create_lgtm_image_repository)
     ],
-    base_url: str = Depends(get_lgtm_images_base_url),
-    token_payload: dict[str, Any] = Depends(verify_token),
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.exec(repository, base_url)
 
@@ -179,7 +179,7 @@ async def retrieve_recently_created_lgtm_images(
     repository: Annotated[
         LgtmImageRepositoryInterface, Depends(create_lgtm_image_repository)
     ],
-    base_url: str = Depends(get_lgtm_images_base_url),
-    token_payload: dict[str, Any] = Depends(verify_token),
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.exec_recently_created(repository, base_url)

--- a/src/presentation/router/lgtm_image_v2_router.py
+++ b/src/presentation/router/lgtm_image_v2_router.py
@@ -32,9 +32,9 @@ router = APIRouter()
 
 
 def create_image_fetch_repository(
-    timeout: int = Depends(get_image_fetch_timeout),
-    max_size: int = Depends(get_max_image_size),
-    allowed_domain: str = Depends(get_image_allowed_domain),
+    timeout: Annotated[int, Depends(get_image_fetch_timeout)],
+    max_size: Annotated[int, Depends(get_max_image_size)],
+    allowed_domain: Annotated[str, Depends(get_image_allowed_domain)],
 ) -> ImageFetchRepositoryInterface:
     return HttpImageFetchRepository(
         timeout=timeout, max_size=max_size, allowed_domain=allowed_domain
@@ -42,7 +42,7 @@ def create_image_fetch_repository(
 
 
 def create_object_storage_repository(
-    bucket_name: str = Depends(get_upload_s3_bucket_name),
+    bucket_name: Annotated[str, Depends(get_upload_s3_bucket_name)],
 ) -> ObjectStorageRepositoryInterface:
     return S3Repository(bucket_name)
 
@@ -129,8 +129,8 @@ async def create_lgtm_image_from_url(
     object_storage_repository: Annotated[
         ObjectStorageRepositoryInterface, Depends(create_object_storage_repository)
     ],
-    base_url: str = Depends(get_lgtm_images_base_url),
-    token_payload: dict[str, Any] = Depends(verify_token),
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.create_from_url(
         image_fetch_repository,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/57

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- 依存関数のパラメータを`Depends()`記法から`Annotated`記法へ移行
- 認証関連（auth.py）の依存関数を更新
- ルーター（lgtm_image_router.py, lgtm_image_v2_router.py）のエンドポイント関数を更新

## 対応しない範囲
- 新機能の追加や既存機能の変更は行わない
- エンドポイントの動作仕様は変更しない

# 変更点概要

FastAPI 0.95以降およびPydantic v2で推奨される`Annotated`記法に移行した。

従来の記法:
```python
def func(param: str = Depends(get_value)): ...
```

新しい記法:
```python
def func(param: Annotated[str, Depends(get_value)]): ...
```

この変更により以下の利点が得られる:
- 型情報とメタデータの明示的な表現
- エディタの補完サポート向上
- 静的解析の精度向上
- FastAPIの最新ベストプラクティスへの準拠

## 変更対象ファイル
- `src/presentation/dependencies/auth.py`: 認証関連の依存関数4箇所
- `src/presentation/router/lgtm_image_router.py`: ルーターの依存パラメータ7箇所
- `src/presentation/router/lgtm_image_v2_router.py`: ルーターの依存パラメータ6箇所

# 補足
参考ドキュメント
https://fastapi.tiangolo.com/tutorial/dependencies/