### PR TITLE
AWS Bedrock/S3 Vectorを使用したテキスト検索機能の基盤実装（ドメイン層・インフラ層）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "cryptography>=46.0.3",
     "types-aioboto3[s3]>=15.4.0",
     "types-python-jose>=3.5.0",
+    "boto3-stubs[bedrock-runtime,s3vectors]>=1.40.71",
 ]
 
 [tool.hatch.metadata]

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,17 @@ COGNITO_REGION: Final[str] = os.getenv("COGNITO_REGION", "ap-northeast-1")
 SENTRY_DSN: Final[str] = os.getenv("SENTRY_DSN", "")
 SENTRY_ENVIRONMENT: Final[str] = os.getenv("SENTRY_ENVIRONMENT", "development")
 
+# AWS Bedrock設定
+AWS_BEDROCK_REGION: Final[str] = os.getenv("AWS_BEDROCK_REGION", "us-east-1")
+AWS_BEDROCK_EMBEDDING_MODEL_ID: Final[str] = os.getenv(
+    "AWS_BEDROCK_EMBEDDING_MODEL_ID", "cohere.embed-v4:0"
+)
+
+# S3 Vector設定
+S3_VECTOR_REGION: Final[str] = os.getenv("S3_VECTOR_REGION", "us-east-1")
+_s3_vector_bucket_name: Optional[str] = os.getenv("S3_VECTOR_BUCKET_NAME")
+_s3_vector_index_name: Optional[str] = os.getenv("S3_VECTOR_INDEX_NAME")
+
 # 必須の環境変数（Noneを許可するが、起動時に検証が必要）
 _cognito_user_pool_id: Optional[str] = os.getenv("COGNITO_USER_POOL_ID")
 _cognito_app_client_id: Optional[str] = os.getenv("COGNITO_APP_CLIENT_ID")
@@ -30,6 +41,8 @@ _image_allowed_domain: Optional[str] = os.getenv("IMAGE_ALLOWED_DOMAIN")
 COGNITO_USER_POOL_ID: Final[str] = _cognito_user_pool_id or ""
 COGNITO_APP_CLIENT_ID: Final[str] = _cognito_app_client_id or ""
 IMAGE_ALLOWED_DOMAIN: Final[str] = _image_allowed_domain or ""
+S3_VECTOR_BUCKET_NAME: Final[str] = _s3_vector_bucket_name or ""
+S3_VECTOR_INDEX_NAME: Final[str] = _s3_vector_index_name or ""
 
 
 def validate_required_config() -> None:
@@ -43,6 +56,12 @@ def validate_required_config() -> None:
 
     if not _image_allowed_domain:
         missing_vars.append("IMAGE_ALLOWED_DOMAIN")
+
+    if not _s3_vector_bucket_name:
+        missing_vars.append("S3_VECTOR_BUCKET_NAME")
+
+    if not _s3_vector_index_name:
+        missing_vars.append("S3_VECTOR_INDEX_NAME")
 
     if missing_vars:
         error_msg = (

--- a/src/domain/lgtm_image_errors.py
+++ b/src/domain/lgtm_image_errors.py
@@ -29,3 +29,15 @@ class ErrImageFetchFailed(Exception):
 
 class ErrUrlNotAccessible(Exception):
     pass
+
+
+class ErrEmbeddingGenerationFailed(Exception):
+    pass
+
+
+class ErrVectorDataCorrupted(Exception):
+    pass
+
+
+class ErrVectorSearchFailed(Exception):
+    pass

--- a/src/domain/lgtm_image_search.py
+++ b/src/domain/lgtm_image_search.py
@@ -1,0 +1,13 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Final, Required, TypedDict
+
+
+class LgtmImageSearchResult(TypedDict):
+    id: Required[str]
+    url: Required[str]
+    similarity_score: Required[float]  # 類似度スコア（0.0〜1.0）
+
+
+# 検索結果のデフォルト最大件数
+DEFAULT_SEARCH_MAX_RESULTS: Final[int] = 9

--- a/src/domain/repository/lgtm_image_search_repository_interface.py
+++ b/src/domain/repository/lgtm_image_search_repository_interface.py
@@ -2,10 +2,10 @@
 
 from typing import Protocol
 
-from domain.lgtm_image_search import LgtmImageSearchResult
+from domain.lgtm_image_search import DEFAULT_SEARCH_MAX_RESULTS, LgtmImageSearchResult
 
 
 class LgtmImageSearchRepositoryInterface(Protocol):
     async def search_by_text(
-        self, query_text: str, max_results: int = 9
+        self, query_text: str, max_results: int = DEFAULT_SEARCH_MAX_RESULTS
     ) -> list[LgtmImageSearchResult]: ...

--- a/src/domain/repository/lgtm_image_search_repository_interface.py
+++ b/src/domain/repository/lgtm_image_search_repository_interface.py
@@ -1,0 +1,11 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Protocol
+
+from domain.lgtm_image_search import LgtmImageSearchResult
+
+
+class LgtmImageSearchRepositoryInterface(Protocol):
+    async def search_by_text(
+        self, query_text: str, max_results: int = 9
+    ) -> list[LgtmImageSearchResult]: ...

--- a/src/infrastructure/bedrock_client.py
+++ b/src/infrastructure/bedrock_client.py
@@ -1,0 +1,78 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+import json
+
+import aioboto3
+
+from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
+
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from log.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class BedrockClient:
+    def __init__(self, region: str, model_id: str) -> None:
+        self.region = region
+        self.model_id = model_id
+        self.session = aioboto3.Session()
+
+    async def generate_text_embedding(self, text: str) -> list[float]:
+        body = json.dumps(
+            {
+                "texts": [text],
+                "input_type": "search_query",
+                "embedding_types": ["float"],
+            }
+        )
+
+        try:
+            async with self.session.client(
+                "bedrock-runtime", region_name=self.region
+            ) as client:
+                response = await client.invoke_model(
+                    modelId=self.model_id,
+                    body=body,
+                    contentType="application/json",
+                    accept="application/json",
+                )
+        except (ClientError, BotoCoreError) as e:
+            # ClientErrorの場合はerror_codeを取得、BotoCoreErrorの場合はNone
+            error_code = getattr(e, "response", {}).get("Error", {}).get("Code")
+            logger.error(
+                f"AWS API call failed: {type(e).__name__}",
+                extra={
+                    "model_id": self.model_id,
+                    "error_type": type(e).__name__,
+                    "error_code": error_code,
+                    "error_message": str(e),
+                },
+            )
+            raise ErrEmbeddingGenerationFailed(
+                f"Failed to invoke Bedrock model: {type(e).__name__}"
+            ) from e
+        except Exception as e:
+            logger.error(
+                "Failed to invoke Bedrock model: Unexpected error",
+                extra={
+                    "model_id": self.model_id,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                },
+            )
+            raise ErrEmbeddingGenerationFailed(
+                f"Failed to invoke Bedrock model: {type(e).__name__}"
+            ) from e
+
+        response_body = json.loads(response["body"].read())
+        # embedding_typesを指定した場合のレスポンス形式:
+        # {"embeddings": {"float": [[float, float, ...]]}}
+        embeddings_by_type = response_body.get("embeddings", {})
+        float_embeddings = embeddings_by_type.get("float", [])
+        if not float_embeddings:
+            raise ErrEmbeddingGenerationFailed("No float embeddings found in response")
+        embeddings: list[float] = float_embeddings[0]
+        return embeddings

--- a/src/infrastructure/lgtm_image_search_repository.py
+++ b/src/infrastructure/lgtm_image_search_repository.py
@@ -1,0 +1,97 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+import math
+
+from domain.lgtm_image_errors import ErrVectorDataCorrupted
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+)
+from infrastructure.bedrock_client import BedrockClient
+from infrastructure.s3_vector_client import S3VectorClient
+
+
+class LgtmImageSearchRepository:
+    """LGTM画像検索リポジトリの実装"""
+
+    def __init__(
+        self,
+        bedrock_client: BedrockClient,
+        s3_vector_client: S3VectorClient,
+        base_url: str,
+    ) -> None:
+        self.bedrock_client = bedrock_client
+        self.s3_vector_client = s3_vector_client
+        self.base_url = base_url
+
+    async def search_by_text(
+        self, query_text: str, max_results: int = DEFAULT_SEARCH_MAX_RESULTS
+    ) -> list[LgtmImageSearchResult]:
+        query_vector = await self.bedrock_client.generate_text_embedding(query_text)
+
+        search_results = await self.s3_vector_client.search_similar_vectors(
+            query_vector, max_results
+        )
+
+        results: list[LgtmImageSearchResult] = []
+        for result in search_results:
+            # key にはDB IDが格納されている - まず存在をチェック
+            image_id = result.get("key")
+            if not image_id:
+                raise ErrVectorDataCorrupted(
+                    "Vector data missing required 'key' field (image ID)"
+                )
+
+            # metadataからS3キーを取得してURLを構築
+            metadata = result.get("metadata", {})
+            source_key = metadata.get("source_key")
+
+            if not source_key:
+                raise ErrVectorDataCorrupted(
+                    f"Vector data missing required 'source_key' in metadata for id: {image_id}"
+                )
+
+            # 例: "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            image_url = f"{self.base_url}/{source_key}"
+
+            # distanceフィールドを厳密に検証
+            # S3 Vectorはdistance(距離)を返す(小さいほど類似度が高い)
+            if "distance" not in result:
+                raise ErrVectorDataCorrupted(
+                    f"Vector data missing 'distance' field for id: {image_id}"
+                )
+
+            distance_value = result["distance"]
+
+            # distanceが数値(int/float)で、非負かつ有限(NaN/infではない)であることを検証
+            if not isinstance(distance_value, (int, float)):
+                raise ErrVectorDataCorrupted(
+                    f"Vector data has non-numeric distance for id: {image_id}, "
+                    f"got type {type(distance_value).__name__}"
+                )
+
+            if distance_value < 0:
+                raise ErrVectorDataCorrupted(
+                    f"Vector data has negative distance for id: {image_id}, "
+                    f"distance={distance_value}"
+                )
+
+            # NaN/infチェック
+            if not math.isfinite(distance_value):
+                raise ErrVectorDataCorrupted(
+                    f"Vector data has non-finite distance (NaN or inf) for id: {image_id}, "
+                    f"distance={distance_value}"
+                )
+
+            # 0-1の範囲のスコアに変換し、高いほど類似度が高くなるようにする
+            similarity_score = 1.0 / (1.0 + distance_value)
+
+            results.append(
+                LgtmImageSearchResult(
+                    id=image_id,
+                    url=image_url,
+                    similarity_score=similarity_score,
+                )
+            )
+
+        return results

--- a/src/infrastructure/lgtm_image_search_repository.py
+++ b/src/infrastructure/lgtm_image_search_repository.py
@@ -7,11 +7,14 @@ from domain.lgtm_image_search import (
     DEFAULT_SEARCH_MAX_RESULTS,
     LgtmImageSearchResult,
 )
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
 from infrastructure.bedrock_client import BedrockClient
 from infrastructure.s3_vector_client import S3VectorClient
 
 
-class LgtmImageSearchRepository:
+class LgtmImageSearchRepository(LgtmImageSearchRepositoryInterface):
     """LGTM画像検索リポジトリの実装"""
 
     def __init__(

--- a/src/infrastructure/s3_vector_client.py
+++ b/src/infrastructure/s3_vector_client.py
@@ -1,0 +1,86 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Any
+
+import aioboto3
+
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from domain.lgtm_image_errors import ErrVectorSearchFailed
+
+from log.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class S3VectorClient:
+    def __init__(self, region: str, bucket_name: str, index_name: str) -> None:
+        self.region = region
+        self.bucket_name = bucket_name
+        self.index_name = index_name
+        self.session = aioboto3.Session()
+
+    async def search_similar_vectors(
+        self, query_vector: list[float], max_results: int
+    ) -> list[dict[str, Any]]:
+        try:
+            async with self.session.client(
+                "s3vectors", region_name=self.region
+            ) as client:
+                response = await client.query_vectors(
+                    vectorBucketName=self.bucket_name,
+                    indexName=self.index_name,
+                    queryVector={"float32": query_vector},
+                    topK=max_results,
+                    returnDistance=True,
+                    returnMetadata=True,
+                )
+        except (ClientError, BotoCoreError) as e:
+            # ClientErrorの場合はerror_codeを取得、BotoCoreErrorの場合はNone
+            error_code = getattr(e, "response", {}).get("Error", {}).get("Code")
+            logger.error(
+                f"AWS API call failed: {type(e).__name__}",
+                extra={
+                    "bucket_name": self.bucket_name,
+                    "index_name": self.index_name,
+                    "error_type": type(e).__name__,
+                    "error_code": error_code,
+                    "error_message": str(e),
+                },
+            )
+            raise ErrVectorSearchFailed(
+                f"Failed to query S3 Vector index '{self.index_name}' "
+                f"in bucket '{self.bucket_name}': {type(e).__name__}"
+            ) from e
+        except Exception as e:
+            logger.error(
+                "Failed to query S3 Vector index: Unexpected error",
+                extra={
+                    "bucket_name": self.bucket_name,
+                    "index_name": self.index_name,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                },
+            )
+            raise ErrVectorSearchFailed(
+                f"Failed to query S3 Vector index '{self.index_name}' "
+                f"in bucket '{self.bucket_name}': {type(e).__name__}"
+            ) from e
+
+        # レスポンスから結果を抽出
+        vectors = response.get("vectors", [])
+        results: list[dict[str, Any]] = []
+
+        for vector in vectors:
+            # デフォルト値を使わず、そのまま返す
+            # 呼び出し元(lgtm_image_search_repository)でバリデーション済み
+            results.append(
+                {
+                    "key": vector.get("key"),
+                    "distance": vector.get("distance"),
+                    "metadata": vector.get("metadata"),
+                }
+            )
+
+        return results

--- a/tests/infrastructure/test_bedrock_client.py
+++ b/tests/infrastructure/test_bedrock_client.py
@@ -1,0 +1,123 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+import json
+from io import BytesIO
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
+from infrastructure.bedrock_client import BedrockClient
+
+
+class TestBedrockClient:
+    @pytest.fixture
+    def mock_bedrock_response(self) -> dict[str, Any]:
+        """モックBedrockレスポンスを返すフィクスチャ（embedding_types指定時の形式）"""
+        return {"embeddings": {"float": [[0.1, 0.2, 0.3, 0.4, 0.5]]}}
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_text_embedding_success(
+        self,
+        mock_session_class: MagicMock,
+        mock_bedrock_response: dict[str, Any],
+    ) -> None:
+        """正常にテキストの埋め込みが生成できることを検証"""
+        # モックレスポンスの設定
+        response_body = json.dumps(mock_bedrock_response)
+        mock_response = {
+            "body": BytesIO(response_body.encode("utf-8")),
+        }
+
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行
+        result = await bedrock_client.generate_text_embedding("test query")
+
+        # 検証
+        assert result == [0.1, 0.2, 0.3, 0.4, 0.5]
+        mock_client.invoke_model.assert_called_once()
+
+        # invoke_modelの引数を検証
+        call_args = mock_client.invoke_model.call_args
+        assert call_args[1]["modelId"] == "cohere.embed-v4:0"
+        assert call_args[1]["contentType"] == "application/json"
+        assert call_args[1]["accept"] == "application/json"
+
+        # リクエストボディの検証
+        request_body = json.loads(call_args[1]["body"])
+        assert request_body["texts"] == ["test query"]
+        assert request_body["input_type"] == "search_query"
+        assert request_body["embedding_types"] == ["float"]
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_text_embedding_api_error(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """Bedrock API呼び出しが失敗した場合にErrEmbeddingGenerationFailedが発生することを検証"""
+        # モックの設定：invoke_modelが例外を投げる
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(
+            side_effect=Exception("Bedrock API call failed")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行と検証
+        with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
+            await bedrock_client.generate_text_embedding("test query")
+
+        # エラーメッセージにモデルIDとエラー型が含まれることを確認
+        assert "Failed to invoke Bedrock model" in str(exc_info.value)
+        assert "Exception" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_text_embedding_no_float_embeddings(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """レスポンスにfloat埋め込みがない場合にエラーが発生することを検証"""
+        # モックレスポンスの設定：floatキーがない
+        mock_response_data = {"embeddings": {"int8": [[1, 2, 3]]}}  # floatがない
+        response_body = json.dumps(mock_response_data)
+        mock_response = {
+            "body": BytesIO(response_body.encode("utf-8")),
+        }
+
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行と検証
+        with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
+            await bedrock_client.generate_text_embedding("test query")
+
+        assert "No float embeddings found in response" in str(exc_info.value)

--- a/tests/infrastructure/test_lgtm_image_search_repository.py
+++ b/tests/infrastructure/test_lgtm_image_search_repository.py
@@ -1,0 +1,339 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from domain.lgtm_image_errors import ErrVectorDataCorrupted
+from infrastructure.lgtm_image_search_repository import (
+    LgtmImageSearchRepository,
+)
+
+
+class TestLgtmImageSearchRepository:
+    @pytest.mark.asyncio
+    async def test_search_by_text_success(self) -> None:
+        """正常にテキスト検索が実行できることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：埋め込みベクトルを返す
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：検索結果を返す（source_key含む）
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "123",
+                    "distance": 0.15,
+                    "metadata": {
+                        "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+                    },
+                },
+                {
+                    "key": "456",
+                    "distance": 0.25,
+                    "metadata": {
+                        "source_key": "2021/03/17/12/6947f291-a46e-453c-a230-0d756d7174cc.webp"
+                    },
+                },
+            ]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行
+        results = await repository.search_by_text("test query", max_results=9)
+
+        # 検証
+        assert len(results) == 2
+
+        # 1件目の検証
+        assert results[0]["id"] == "123"
+        assert (
+            results[0]["url"]
+            == "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+        )
+        # distance=0.15 -> similarity_score=1.0/(1.0+0.15)≈0.8696
+        assert results[0]["similarity_score"] == pytest.approx(1.0 / 1.15)
+
+        # 2件目の検証
+        assert results[1]["id"] == "456"
+        assert (
+            results[1]["url"]
+            == "https://example.com/2021/03/17/12/6947f291-a46e-453c-a230-0d756d7174cc.webp"
+        )
+        # distance=0.25 -> similarity_score=1.0/(1.0+0.25)=0.8
+        assert results[1]["similarity_score"] == pytest.approx(0.8)
+
+        # モックメソッドの呼び出しを検証
+        mock_bedrock_client.generate_text_embedding.assert_called_once_with(
+            "test query"
+        )
+        mock_s3_vector_client.search_similar_vectors.assert_called_once_with(
+            [0.1, 0.2, 0.3, 0.4, 0.5], 9
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_empty_result(self) -> None:
+        """検索結果が空の場合を検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3]
+        )
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(return_value=[])
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行
+        results = await repository.search_by_text("no match query")
+
+        # 検証
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_bedrock_error(self) -> None:
+        """Bedrock API呼び出しが失敗した場合に例外が伝播することを検証"""
+        # モックの設定：BedrockClientが例外を投げる
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            side_effect=Exception("Bedrock API error")
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(Exception) as exc_info:
+            await repository.search_by_text("test query")
+
+        assert "Bedrock API error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_s3_vector_error(self) -> None:
+        """S3 Vector API呼び出しが失敗した場合に例外が伝播することを検証"""
+        # モックの設定：S3VectorClientが例外を投げる
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3]
+        )
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            side_effect=Exception("S3 Vector API error")
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(Exception) as exc_info:
+            await repository.search_by_text("test query")
+
+        assert "S3 Vector API error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_raises_error_when_source_key_missing(self) -> None:
+        """メタデータにsource_keyがない場合、ErrVectorDataCorruptedが発生することを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3]
+        )
+
+        # メタデータにsource_keyがない検索結果
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "123",
+                    "distance": 0.1,
+                    "metadata": {},  # source_keyなし
+                },
+            ]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_text("test query")
+
+        assert "Vector data missing required 'source_key'" in str(exc_info.value)
+        assert "123" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_raises_error_when_metadata_missing(self) -> None:
+        """メタデータ自体がない場合、ErrVectorDataCorruptedが発生することを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3]
+        )
+
+        # メタデータがない検索結果
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "456",
+                    "distance": 0.1,
+                    # metadataキー自体がない
+                },
+            ]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_text("test query")
+
+        assert "Vector data missing required 'source_key'" in str(exc_info.value)
+        assert "456" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("distance_value", "expected_error_msg"),
+        [
+            (None, "Vector data missing 'distance' field for id: 123"),
+            ("invalid", "Vector data has non-numeric distance for id: 123"),
+            (-0.5, "Vector data has negative distance for id: 123"),
+            (
+                float("nan"),
+                "Vector data has non-finite distance (NaN or inf) for id: 123",
+            ),
+            (
+                float("inf"),
+                "Vector data has non-finite distance (NaN or inf) for id: 123",
+            ),
+        ],
+        ids=["missing", "non_numeric", "negative", "nan", "inf"],
+    )
+    async def test_search_by_text_raises_error_on_invalid_distance(
+        self,
+        distance_value: Any,
+        expected_error_msg: str,
+    ) -> None:
+        """distanceフィールドが不正な値の場合、ErrVectorDataCorruptedを投げることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # テストケースに応じた結果データを構築
+        result_data: dict[str, Any] = {
+            "key": "123",
+            "metadata": {
+                "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            },
+        }
+        if distance_value is not None:
+            result_data["distance"] = distance_value
+
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[result_data]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行: 例外が投げられることを検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_text("test query", max_results=9)
+
+        # エラーメッセージの確認
+        assert expected_error_msg in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "key_value",
+        [None, ""],
+        ids=["missing", "empty_string"],
+    )
+    async def test_search_by_text_raises_error_on_invalid_key(
+        self,
+        key_value: Any,
+    ) -> None:
+        """keyフィールドが不正な値の場合、ErrVectorDataCorruptedを投げることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_text_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # テストケースに応じた結果データを構築
+        result_data: dict[str, Any] = {
+            "distance": 0.15,
+            "metadata": {
+                "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            },
+        }
+        if key_value is not None:
+            result_data["key"] = key_value
+
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[result_data]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行: 例外が投げられることを検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_text("test query", max_results=9)
+
+        # エラーメッセージの確認
+        assert "Vector data missing required 'key' field" in str(exc_info.value)

--- a/tests/infrastructure/test_s3_vector_client.py
+++ b/tests/infrastructure/test_s3_vector_client.py
@@ -1,0 +1,152 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from infrastructure.s3_vector_client import S3VectorClient
+
+
+from domain.lgtm_image_errors import ErrVectorSearchFailed
+
+
+class TestS3VectorClient:
+    @pytest.fixture
+    def mock_s3vectors_response(self) -> dict[str, Any]:
+        """モックS3 Vectorsレスポンスを返すフィクスチャ"""
+        return {
+            "vectors": [
+                {
+                    "key": "1",
+                    "distance": 0.12345,
+                    "metadata": {
+                        "source_key": "2024/01/15/10/a1b2c3d4-e5f6-7890-abcd-ef1234567890.webp"
+                    },
+                },
+                {
+                    "key": "2",
+                    "distance": 0.28734,
+                    "metadata": {
+                        "source_key": "2024/02/20/14/b2c3d4e5-f6a7-8901-bcde-f12345678901.webp"
+                    },
+                },
+            ],
+            "distanceMetric": "cosine",
+        }
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.s3_vector_client.aioboto3.Session")
+    async def test_search_similar_vectors_success(
+        self,
+        mock_session_class: MagicMock,
+        mock_s3vectors_response: dict[str, Any],
+    ) -> None:
+        """正常に類似ベクトルを検索できることを検証"""
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.query_vectors = AsyncMock(return_value=mock_s3vectors_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        s3_vector_client = S3VectorClient(
+            region="us-west-2", bucket_name="test-bucket", index_name="test-index"
+        )
+
+        # テスト実行
+        query_vector = [0.1, 0.2, 0.3]
+        result = await s3_vector_client.search_similar_vectors(
+            query_vector, max_results=9
+        )
+
+        # 検証
+        assert len(result) == 2
+        assert result[0]["key"] == "1"
+        assert result[0]["distance"] == 0.12345
+        assert (
+            result[0]["metadata"]["source_key"]
+            == "2024/01/15/10/a1b2c3d4-e5f6-7890-abcd-ef1234567890.webp"
+        )
+        assert result[1]["key"] == "2"
+        assert result[1]["distance"] == 0.28734
+        assert (
+            result[1]["metadata"]["source_key"]
+            == "2024/02/20/14/b2c3d4e5-f6a7-8901-bcde-f12345678901.webp"
+        )
+
+        # query_vectorsの呼び出しを検証
+        mock_client.query_vectors.assert_called_once()
+        call_args = mock_client.query_vectors.call_args[1]
+        assert call_args["vectorBucketName"] == "test-bucket"
+        assert call_args["indexName"] == "test-index"
+        assert call_args["queryVector"] == {"float32": query_vector}
+        assert call_args["topK"] == 9
+        assert call_args["returnDistance"] is True
+        assert call_args["returnMetadata"] is True
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.s3_vector_client.aioboto3.Session")
+    async def test_search_similar_vectors_empty_result(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """検索結果が空の場合を検証"""
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.query_vectors = AsyncMock(return_value={"vectors": []})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        s3_vector_client = S3VectorClient(
+            region="us-west-2", bucket_name="test-bucket", index_name="test-index"
+        )
+
+        # テスト実行
+        query_vector = [0.1, 0.2, 0.3]
+        result = await s3_vector_client.search_similar_vectors(
+            query_vector, max_results=9
+        )
+
+        # 検証
+        assert result == []
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.s3_vector_client.aioboto3.Session")
+    async def test_search_similar_vectors_api_error(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """S3 Vectors API呼び出しが失敗した場合にErrVectorSearchFailedが発生することを検証"""
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.query_vectors = AsyncMock(
+            side_effect=Exception("S3 Vectors API call failed")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        s3_vector_client = S3VectorClient(
+            region="us-west-2", bucket_name="test-bucket", index_name="test-index"
+        )
+
+        # テスト実行と検証
+        query_vector = [0.1, 0.2, 0.3]
+        with pytest.raises(ErrVectorSearchFailed) as exc_info:
+            await s3_vector_client.search_similar_vectors(query_vector, max_results=9)
+
+        # エラーメッセージの検証
+        assert "Failed to query S3 Vector index 'test-index'" in str(exc_info.value)
+        assert "in bucket 'test-bucket'" in str(exc_info.value)
+        assert "Exception" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,27 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3-stubs"
+version = "1.40.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/d8/afe08e0c3740d7f04f4a1c5b9960ee26d3878b56df57d8abad87131565dc/boto3_stubs-1.40.71.tar.gz", hash = "sha256:4f9ccbfc51eada139803fadd7b247a806bdb2ae9b26260b8750aa9a776c7b1ac", size = 99398, upload-time = "2025-11-11T20:39:05.993Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/bb/3d407b34e2c01e8294b7304f7856d6f0712871f3f0e1b7e2db6c31fe1bdc/boto3_stubs-1.40.71-py3-none-any.whl", hash = "sha256:0bdd1033b789bc0a145101f4e27f1770d3a65d5f6841db63f774fceef23e48c5", size = 68982, upload-time = "2025-11-11T20:38:56.497Z" },
+]
+
+[package.optional-dependencies]
+bedrock-runtime = [
+    { name = "mypy-boto3-bedrock-runtime" },
+]
+s3vectors = [
+    { name = "mypy-boto3-s3vectors" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.40.49"
 source = { registry = "https://pypi.org/simple" }
@@ -643,6 +664,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3-stubs", extra = ["bedrock-runtime", "s3vectors"] },
     { name = "cryptography" },
     { name = "mypy" },
     { name = "pytest" },
@@ -669,6 +691,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3-stubs", extras = ["bedrock-runtime", "s3vectors"], specifier = ">=1.40.71" },
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pytest", specifier = ">=8.4.2" },
@@ -811,6 +834,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
     { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
     { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bedrock-runtime"
+version = "1.40.62"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/d0/ca3c58a1284f9142959fb00889322d4889278c2e4b165350d8e294c07d9c/mypy_boto3_bedrock_runtime-1.40.62.tar.gz", hash = "sha256:5505a60e2b5f9c845ee4778366d49c93c3723f6790d0cec116d8fc5f5609d846", size = 28611, upload-time = "2025-10-29T21:43:02.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/c5/ad62e5f80684ce5fe878d320634189ef29d00ee294cd62a37f3e51719f47/mypy_boto3_bedrock_runtime-1.40.62-py3-none-any.whl", hash = "sha256:e383e70b5dffb0b335b49fc1b2772f0d35118f99994bc7e731445ba0ab237831", size = 34497, upload-time = "2025-10-29T21:43:01.591Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3vectors"
+version = "1.40.60"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e8/f5e2f12dbdbaf62496525e5aff2fd9910ae649ebec0ca3b5ebdc2fde3d33/mypy_boto3_s3vectors-1.40.60.tar.gz", hash = "sha256:273ed5921ce17febce2638db1087465e3c6ce37f38aa45cd15e477a570d939fb", size = 18183, upload-time = "2025-10-27T19:44:45.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/bf/0818508300b8481b1fd3713549e6e3cd886887c02af0c11822ae47949830/mypy_boto3_s3vectors-1.40.60-py3-none-any.whl", hash = "sha256:01b6c645196286d3ebab5489171efd06124d9ef0d890eb998ee47c141b03681e", size = 23586, upload-time = "2025-10-27T19:44:44.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/59

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**
- Domain層
    - エンティティとリポジトリインターフェースの実装
- Infrastructure層
    - AWS Bedrock Clientの実装
    - S3 Vector Clientの実装
    - 検索リポジトリ実装
- 各コンポーネントのユニットテストの実装

**対応しない範囲**
- Usecase層の実装（別PRで対応）
- Presentation層（Controller、Router）の実装（別PRで対応）
- main.pyへのルーター登録（別PRで対応）

# 変更点概要

テキストから画像を検索するAPI機能のうち、Domain層とInfrastructure層を実装した。

**Domain層**
- `LgtmImageSearchResult` エンティティの定義
- `LgtmImageSearchRepositoryInterface` の定義
- 検索機能用のエラークラス追加（`ErrEmbeddingGenerationFailed`, `ErrVectorSearchFailed`, `ErrVectorDataCorrupted`）

**Infrastructure層**
- `BedrockClient`: Cohere Embed v4モデルを使用したテキスト埋め込み生成
- `S3VectorClient`: S3 Vectorを使用したベクトル類似度検索
- `LgtmImageSearchRepository`: BedrockとS3 Vectorを組み合わせたテキスト検索機能

**設定**
- AWS Bedrock、S3 Vector関連の環境変数を`config.py`に追加
- boto3-stubsの型定義を追加

**テスト**
 - 各クライアントとリポジトリのユニットテストを実装

# 補足情報
- 本PRはIssue #59 の段階的実装の第1段階である
- ユースケース層以降の実装は後続PRで対応予定