### PR TITLE
テキスト検索機能のユースケース層を実装

### DIFF
--- a/src/domain/lgtm_image_errors.py
+++ b/src/domain/lgtm_image_errors.py
@@ -41,3 +41,7 @@ class ErrVectorDataCorrupted(Exception):
 
 class ErrVectorSearchFailed(Exception):
     pass
+
+
+class ErrInvalidSearchQuery(Exception):
+    pass

--- a/src/domain/lgtm_image_search.py
+++ b/src/domain/lgtm_image_search.py
@@ -9,5 +9,8 @@ class LgtmImageSearchResult(TypedDict):
     similarity_score: Required[float]  # 類似度スコア（0.0〜1.0）
 
 
+# 検索クエリの最大文字数
+MAX_QUERY_LENGTH: Final[int] = 500
+
 # 検索結果のデフォルト最大件数
 DEFAULT_SEARCH_MAX_RESULTS: Final[int] = 9

--- a/src/usecase/search_lgtm_images_by_text.py
+++ b/src/usecase/search_lgtm_images_by_text.py
@@ -1,0 +1,77 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+    MAX_QUERY_LENGTH,
+)
+from domain.lgtm_image_errors import ErrInvalidSearchQuery
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
+from log.logger import get_logger
+
+import unicodedata
+
+logger = get_logger(__name__)
+
+
+class SearchLgtmImagesByTextUsecase:
+    @staticmethod
+    def _normalize_query_text(query_text: str) -> str:
+        # 1. Unicode正規化（NFKC）- 全角/半角、濁点の統一
+        normalized = unicodedata.normalize("NFKC", query_text)
+
+        # 2. トリムと空白の正規化 - 連続する空白を単一スペースに
+        normalized = " ".join(normalized.strip().split())
+
+        return normalized
+
+    @staticmethod
+    def _validate_query_text(query_text: str) -> None:
+        # 空文字チェック
+        if not query_text:
+            logger.warning("Empty query text provided after normalization")
+            raise ErrInvalidSearchQuery("Search query cannot be empty")
+
+        # 文字数制限チェック
+        if len(query_text) > MAX_QUERY_LENGTH:
+            logger.warning(
+                "Query text exceeds maximum length",
+                extra={
+                    "query_length": len(query_text),
+                    "max_length": MAX_QUERY_LENGTH,
+                },
+            )
+            raise ErrInvalidSearchQuery(
+                f"Search query must be {MAX_QUERY_LENGTH} characters or less"
+            )
+
+    @staticmethod
+    async def execute(
+        repository: LgtmImageSearchRepositoryInterface,
+        query_text: str,
+    ) -> list[LgtmImageSearchResult]:
+        logger.info("Executing SearchLgtmImagesByTextUsecase")
+
+        normalized_query = SearchLgtmImagesByTextUsecase._normalize_query_text(
+            query_text
+        )
+
+        SearchLgtmImagesByTextUsecase._validate_query_text(normalized_query)
+
+        logger.info(
+            "Query normalized and validated",
+            extra={"query_length": len(normalized_query)},
+        )
+
+        results = await repository.search_by_text(
+            normalized_query, max_results=DEFAULT_SEARCH_MAX_RESULTS
+        )
+
+        logger.info(
+            "SearchLgtmImagesByTextUsecase completed successfully",
+            extra={"results_count": len(results)},
+        )
+
+        return results

--- a/tests/usecase/test_search_lgtm_images_by_text.py
+++ b/tests/usecase/test_search_lgtm_images_by_text.py
@@ -1,0 +1,256 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.lgtm_image_errors import ErrInvalidSearchQuery
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+    MAX_QUERY_LENGTH,
+)
+from usecase.search_lgtm_images_by_text import SearchLgtmImagesByTextUsecase
+
+
+class TestNormalizeQueryText:
+    """_normalize_query_textメソッドの単体テスト."""
+
+    @pytest.mark.parametrize(
+        "input_text,expected,description",
+        [
+            # Unicode正規化（NFKC）のテスト
+            ("ＡＢＣ１２３", "ABC123", "全角英数字が半角に正規化される"),
+            ("ｶﾀｶﾅ", "カタカナ", "半角カタカナが全角に正規化される"),
+            ("か\u3099", "が", "分離された濁点が結合文字に正規化される"),
+            # 空白正規化のテスト
+            (
+                "hello    world",
+                "hello world",
+                "連続する空白が単一スペースに正規化される",
+            ),
+            ("hello\t\nworld", "hello world", "タブと改行が単一スペースに正規化される"),
+            ("hello　world", "hello world", "全角スペースが半角スペースに正規化される"),
+            # トリムのテスト
+            ("  hello world  ", "hello world", "前後の空白が削除される"),
+            # 複合パターン
+            (
+                "  ｶﾀｶﾅ　　ＡＢＣ    １２３\n\ttest  ",
+                "カタカナ ABC 123 test",
+                "複雑な混在入力が正しく正規化される",
+            ),
+            ("   \t\n   ", "", "空白のみの入力は空文字列になる"),
+        ],
+    )
+    def test_normalizes_query_text(
+        self, input_text: str, expected: str, description: str
+    ) -> None:
+        """クエリテキストが正しく正規化される."""
+        # Act
+        result = SearchLgtmImagesByTextUsecase._normalize_query_text(input_text)
+
+        # Assert
+        assert result == expected, description
+
+    def test_normalizes_dakuten_separately_to_combined_verifies_length(self) -> None:
+        """分離された濁点が1文字に結合されることを長さで確認."""
+        # Arrange
+        query_text = "か\u3099"  # U+304B + U+3099 (基底文字 + 結合濁点)
+
+        # Act
+        result = SearchLgtmImagesByTextUsecase._normalize_query_text(query_text)
+
+        # Assert
+        assert result == "が"  # U+304C (合成済み文字)
+        assert len(result) == 1  # 1文字に結合される
+
+
+class TestValidateQueryText:
+    """_validate_query_textメソッドの単体テスト."""
+
+    @pytest.mark.parametrize(
+        "query_text,description",
+        [
+            ("a", "1文字のクエリは受け入れられる"),
+            ("猫の画像を検索", "有効な日本語クエリは受け入れられる"),
+            ("search for cat images", "有効な英語クエリは受け入れられる"),
+            (
+                "a" * MAX_QUERY_LENGTH,
+                f"最大文字数（{MAX_QUERY_LENGTH}文字）のクエリは受け入れられる",
+            ),
+            (
+                "あ" * MAX_QUERY_LENGTH,
+                f"日本語で{MAX_QUERY_LENGTH}文字のクエリは受け入れられる",
+            ),
+        ],
+    )
+    def test_accepts_valid_query(self, query_text: str, description: str) -> None:
+        """有効なクエリが受け入れられる."""
+        # Act & Assert - 例外が発生しないことを確認
+        try:
+            SearchLgtmImagesByTextUsecase._validate_query_text(query_text)
+        except ErrInvalidSearchQuery:
+            pytest.fail(f"{description}のに例外が発生した")
+
+    @pytest.mark.parametrize(
+        "query_text,expected_message",
+        [
+            (
+                "",
+                "Search query cannot be empty",
+            ),
+            (
+                "a" * (MAX_QUERY_LENGTH + 1),
+                f"Search query must be {MAX_QUERY_LENGTH} characters or less",
+            ),
+            (
+                "あ" * (MAX_QUERY_LENGTH + 1),
+                f"Search query must be {MAX_QUERY_LENGTH} characters or less",
+            ),
+        ],
+        ids=[
+            "空文字列でErrInvalidSearchQueryが発生する",
+            f"{MAX_QUERY_LENGTH + 1}文字でErrInvalidSearchQueryが発生する",
+            f"日本語{MAX_QUERY_LENGTH + 1}文字でErrInvalidSearchQueryが発生する",
+        ],
+    )
+    def test_raises_invalid_search_query_for_invalid_query(
+        self, query_text: str, expected_message: str
+    ) -> None:
+        """無効なクエリでErrInvalidSearchQueryが発生する."""
+        # Act & Assert
+        with pytest.raises(ErrInvalidSearchQuery, match=expected_message):
+            SearchLgtmImagesByTextUsecase._validate_query_text(query_text)
+
+
+class TestSearchLgtmImagesByTextUsecase:
+    """SearchLgtmImagesByTextUsecaseの統合テスト.
+
+    正規化とバリデーションの詳細テストは
+    TestNormalizeQueryTextとTestValidateQueryTextで実施。
+    ここでは正規化→バリデーション→リポジトリ呼び出しの
+    統合的な動作を確認する。
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_valid_query(self) -> None:
+        """正常系: 有効なクエリテキストから画像が返る."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_results: list[LgtmImageSearchResult] = [
+            {
+                "id": "1",
+                "url": "https://example.com/image1.webp",
+                "similarity_score": 0.95,
+            },
+            {
+                "id": "2",
+                "url": "https://example.com/image2.webp",
+                "similarity_score": 0.87,
+            },
+            {
+                "id": "3",
+                "url": "https://example.com/image3.webp",
+                "similarity_score": 0.75,
+            },
+        ]
+        mock_repository.search_by_text.return_value = mock_results
+
+        query_text = "happy cat"
+
+        # Act
+        result = await SearchLgtmImagesByTextUsecase.execute(
+            repository=mock_repository,
+            query_text=query_text,
+        )
+
+        # Assert
+        assert len(result) == 3
+        assert result == mock_results
+        mock_repository.search_by_text.assert_called_once_with(
+            query_text, max_results=DEFAULT_SEARCH_MAX_RESULTS
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_empty_results(self) -> None:
+        """正常系: 検索結果が0件の場合でも空のリストが返る."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text.return_value = []
+
+        query_text = "nonexistent keyword"
+
+        # Act
+        result = await SearchLgtmImagesByTextUsecase.execute(
+            repository=mock_repository,
+            query_text=query_text,
+        )
+
+        # Assert
+        assert len(result) == 0
+        assert result == []
+        mock_repository.search_by_text.assert_called_once_with(
+            query_text, max_results=DEFAULT_SEARCH_MAX_RESULTS
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_value_error_with_empty_string(self) -> None:
+        """異常系: 空文字列のクエリでErrInvalidSearchQueryが発生する."""
+        # Arrange
+        mock_repository = AsyncMock()
+        query_text = ""
+
+        # Act & Assert
+        with pytest.raises(ErrInvalidSearchQuery, match="Search query cannot be empty"):
+            await SearchLgtmImagesByTextUsecase.execute(
+                repository=mock_repository,
+                query_text=query_text,
+            )
+
+        # リポジトリは呼ばれないことを確認
+        mock_repository.search_by_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_value_error_when_query_exceeds_max_length(
+        self,
+    ) -> None:
+        """異常系: 文字数制限を超えるクエリでErrInvalidSearchQueryが発生する."""
+        # Arrange
+        mock_repository = AsyncMock()
+        # MAX_QUERY_LENGTHを超えるクエリ
+        query_text = "a" * (MAX_QUERY_LENGTH + 1)
+
+        # Act & Assert
+        with pytest.raises(
+            ErrInvalidSearchQuery,
+            match=f"Search query must be {MAX_QUERY_LENGTH} characters or less",
+        ):
+            await SearchLgtmImagesByTextUsecase.execute(
+                repository=mock_repository,
+                query_text=query_text,
+            )
+
+        # リポジトリは呼ばれないことを確認
+        mock_repository.search_by_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_calls_repository_with_normalized_query(self) -> None:
+        """正常系: 正規化されたクエリでリポジトリが呼ばれる."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text.return_value = []
+
+        # 正規化が必要なクエリ（前後に空白、連続空白）
+        query_text = "  test    query  "
+        expected_normalized = "test query"
+
+        # Act
+        await SearchLgtmImagesByTextUsecase.execute(
+            repository=mock_repository,
+            query_text=query_text,
+        )
+
+        # Assert - 正規化されたクエリでリポジトリが呼ばれる
+        mock_repository.search_by_text.assert_called_once_with(
+            expected_normalized, max_results=DEFAULT_SEARCH_MAX_RESULTS
+        )

--- a/tests/usecase/test_search_lgtm_images_by_text.py
+++ b/tests/usecase/test_search_lgtm_images_by_text.py
@@ -194,7 +194,7 @@ class TestSearchLgtmImagesByTextUsecase:
         )
 
     @pytest.mark.asyncio
-    async def test_execute_raises_value_error_with_empty_string(self) -> None:
+    async def test_execute_raises_invalid_search_query_with_empty_string(self) -> None:
         """異常系: 空文字列のクエリでErrInvalidSearchQueryが発生する."""
         # Arrange
         mock_repository = AsyncMock()
@@ -211,7 +211,7 @@ class TestSearchLgtmImagesByTextUsecase:
         mock_repository.search_by_text.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_execute_raises_value_error_when_query_exceeds_max_length(
+    async def test_execute_raises_invalid_search_query_when_query_exceeds_max_length(
         self,
     ) -> None:
         """異常系: 文字数制限を超えるクエリでErrInvalidSearchQueryが発生する."""


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/59

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- テキスト検索機能のユースケース層実装（`SearchLgtmImagesByTextUsecase`）
- クエリテキストの正規化処理（Unicode正規化、空白の統一）
- クエリテキストのバリデーション処理（空文字チェック、文字数制限チェック）
- 関連するドメイン層の追加（エラー定義、定数定義）
- ユースケース層のテスト実装

## 対応しない範囲
- プレゼンテーション層（router/controller）の実装は別PRで対応する
- APIエンドポイントの公開は別PRで対応する

# 変更点概要

テキストから画像を検索する機能のユースケース層を実装した。ユーザーが入力するテキストクエリを信頼できる形式に整えてから検索を実行するため、正規化処理とバリデーション処理をユースケース層に集約している。

## 主な実装内容

### 1. ドメイン層の追加定義
- **エラー定義**（`lgtm_image_errors.py`）
  - `ErrInvalidSearchQuery`: 無効な検索クエリエラーを追加
- **定数定義**（`lgtm_image_search.py`）
  - `MAX_QUERY_LENGTH`: クエリ最大文字数（500文字）を追加

### 2. ユースケース層の実装
- **クエリテキストの正規化**（`_normalize_query_text`）
  - Unicode正規化（NFKC）により全角/半角、濁点の揺れを統一
  - 前後のトリムと連続する空白を単一スペースに変換

- **クエリテキストのバリデーション**（`_validate_query_text`）
  - 空文字チェック
  - 文字数制限チェック（最大500文字）
  - バリデーション失敗時は`ErrInvalidSearchQuery`例外を発生

- **検索実行**（`execute`）
  - 正規化とバリデーションを経たクエリでリポジトリを呼び出し
  - 最大9件の検索結果を取得
  - 適切なログ出力による動作の追跡

### 3. テスト実装
- 正規化処理のテスト（Unicode正規化、空白処理、複合パターン）
- バリデーション処理のテスト（有効/無効パターン）
- ユースケース統合テスト（正常系・異常系）

## 技術的な意思決定

### なぜUnicode正規化（NFKC）を採用したのか

ユーザー入力の揺れを吸収し、検索精度を向上させるためである。具体的には以下のケースに対応する。

- 全角英数字と半角英数字の統一（例: `ＡＢＣ` → `ABC`）
- 半角カタカナと全角カタカナの統一（例: `ｶﾀｶﾅ` → `カタカナ`）
- 分離された濁点の結合（例: `か゛` → `が`）

# レビュアーに重点的にチェックして欲しい点

- クエリ最大文字数（500文字）が適切か