### PR TITLE
テキスト検索APIエンドポイントの実装

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,14 +1,58 @@
-# LGTM画像のベースURL
-export LGTM_IMAGES_BASE_URL=
+# ========================================
+# 必須の環境変数
+# ========================================
 
-# LGTM画像のアップロード先S3バケット
-export UPLOAD_S3_BUCKET_NAME=
+# AWS Cognito設定（JWT認証）
+export COGNITO_USER_POOL_ID=
+export COGNITO_APP_CLIENT_ID=
 
-# PlanetScale接続情報
+# 画像取得設定（URL画像取得機能用）
+export IMAGE_ALLOWED_DOMAIN=
+
+# AWS S3 Vector設定（ベクトル検索機能用）
+export S3_VECTOR_BUCKET_NAME=
+export S3_VECTOR_INDEX_NAME=
+
+# データベース接続情報
 export DATABASE_USER=
 export DATABASE_PASSWORD=
 export DATABASE_HOST=
 export DATABASE_NAME=
+
+# ========================================
+# オプションの環境変数（デフォルト値あり）
+# ========================================
+
+# LGTM画像のベースURL（デフォルト: lgtm-images.lgtmeow.com）
+export LGTM_IMAGES_BASE_URL=
+
+# LGTM画像のアップロード先S3バケット（デフォルト: 空文字）
+export UPLOAD_S3_BUCKET_NAME=
+
+# ログ設定（デフォルト: INFO）
+export LOG_LEVEL=INFO
+
+# AWS Cognito設定（デフォルト: ap-northeast-1）
+export COGNITO_REGION=ap-northeast-1
+
+# AWS Bedrock設定（埋め込みモデル用）
+export AWS_BEDROCK_REGION=us-east-1
+export AWS_BEDROCK_EMBEDDING_MODEL_ID=cohere.embed-v4:0
+
+# AWS S3 Vector設定（デフォルト: us-east-1）
+export S3_VECTOR_REGION=us-east-1
+
+# Sentry設定（エラー監視、デフォルト: 空文字）
+export SENTRY_DSN=
+export SENTRY_ENVIRONMENT=development
+
+# ========================================
+# テスト専用の環境変数
+# ========================================
+
+# テスト用ローカルMySQL接続情報
+export TEST_DATABASE_PASSWORD=
+export TEST_DATABASE_ROOT_PASSWORD=
 
 # PlanetScale API設定（テスト用）
 export PLANETSCALE_ORG_NAME=
@@ -16,22 +60,3 @@ export PLANETSCALE_SERVICE_TOKEN_ID=
 export PLANETSCALE_SERVICE_TOKEN=
 export PLANETSCALE_DATABASE_NAME=
 export PLANETSCALE_BRANCH_NAME=
-
-# テスト用ローカルMySQL接続情報
-export TEST_DATABASE_PASSWORD=
-export TEST_DATABASE_ROOT_PASSWORD=
-
-# ログ設定
-export LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
-
-# AWS Cognito設定（JWT認証）
-export COGNITO_REGION=ap-northeast-1
-export COGNITO_USER_POOL_ID=
-export COGNITO_APP_CLIENT_ID=
-
-# 画像取得設定（URL画像取得機能用）
-export IMAGE_ALLOWED_DOMAIN=
-
-# Sentry設定（エラー監視）
-export SENTRY_DSN=
-export SENTRY_ENVIRONMENT=

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ APIはシンプルなRESTパターンに従い、3つのエンドポイントを
 1. **GET /lgtm-images** - ランダムなLGTM画像を返す
 2. **POST /lgtm-images** - 新しいLGTM画像を作成（base64画像と拡張子を受け取る）
 3. **GET /lgtm-images/recently-created** - 最近作成されたLGTM画像を返す
+4. **POST /lgtm-images/search/text** - テキストからLGTM画像を検索
 
 レスポンスモデルはPydanticのBaseModelを使用して定義されており、JSONフィールドにはキャメルケースを使用します（例: `imageUrl`, `imageExtension`）。
 

--- a/README.md
+++ b/README.md
@@ -51,44 +51,73 @@ cp .envrc.example .envrc
 
 #### 環境変数一覧
 
+##### 必須の環境変数
+
+アプリケーションの起動に必須の環境変数です。未設定の場合は起動時にエラーが発生します。
+
 ```bash
-# LGTM画像のベースURL
-export LGTM_IMAGES_BASE_URL=
-
-# LGTM画像のアップロード先S3バケット
-export UPLOAD_S3_BUCKET_NAME=
-
-# PlanetScale接続情報
-export DATABASE_USER=
-export DATABASE_PASSWORD=
-export DATABASE_HOST=
-export DATABASE_NAME=
-
-# PlanetScale API設定（テスト用）
-export PLANETSCALE_ORG_NAME=
-export PLANETSCALE_SERVICE_TOKEN_ID=
-export PLANETSCALE_SERVICE_TOKEN=
-export PLANETSCALE_DATABASE_NAME=
-export PLANETSCALE_BRANCH_NAME=
-
-# テスト用ローカルMySQL接続情報
-export TEST_DATABASE_PASSWORD=
-export TEST_DATABASE_ROOT_PASSWORD=
-
-# ログ設定
-export LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
-
 # AWS Cognito設定（JWT認証）
-export COGNITO_REGION=ap-northeast-1
-export COGNITO_USER_POOL_ID=
-export COGNITO_APP_CLIENT_ID=
+export COGNITO_USER_POOL_ID=         # CognitoユーザープールID
+export COGNITO_APP_CLIENT_ID=        # CognitoアプリクライアントID
 
 # 画像取得設定（URL画像取得機能用）
-export IMAGE_ALLOWED_DOMAIN=  # アクセス可能なドメイン（例: example.r2.cloudflarestorage.com）
+export IMAGE_ALLOWED_DOMAIN=         # アクセス可能なドメイン（例: example.r2.cloudflarestorage.com）
+
+# AWS S3 Vector設定（ベクトル検索機能用）
+export S3_VECTOR_BUCKET_NAME=        # S3ベクトルストレージのバケット名
+export S3_VECTOR_INDEX_NAME=         # S3ベクトルインデックス名
+
+# データベース接続情報
+export DATABASE_USER=                # データベースユーザー名
+export DATABASE_PASSWORD=            # データベースパスワード
+export DATABASE_HOST=                # データベースホスト
+export DATABASE_NAME=                # データベース名
+```
+
+##### オプションの環境変数
+
+デフォルト値が設定されているため、必要に応じて設定してください。
+
+```bash
+# LGTM画像のベースURL
+export LGTM_IMAGES_BASE_URL=lgtm-images.lgtmeow.com  # デフォルト: lgtm-images.lgtmeow.com
+
+# LGTM画像のアップロード先S3バケット
+export UPLOAD_S3_BUCKET_NAME=        # デフォルト: 空文字
+
+# ログ設定
+export LOG_LEVEL=INFO                # デフォルト: INFO（DEBUG, INFO, WARNING, ERROR, CRITICAL）
+
+# AWS Cognito設定
+export COGNITO_REGION=ap-northeast-1 # デフォルト: ap-northeast-1
+
+# AWS Bedrock設定（埋め込みモデル用）
+export AWS_BEDROCK_REGION=us-east-1  # デフォルト: us-east-1
+export AWS_BEDROCK_EMBEDDING_MODEL_ID=cohere.embed-v4:0  # デフォルト: cohere.embed-v4:0
+
+# AWS S3 Vector設定
+export S3_VECTOR_REGION=us-east-1    # デフォルト: us-east-1
 
 # Sentry設定（エラー監視）
-export SENTRY_DSN=           # SentryのDSN（未設定時はSentry無効）
-export SENTRY_ENVIRONMENT=   # 実行環境名
+export SENTRY_DSN=                   # デフォルト: 空文字（未設定時はSentry無効）
+export SENTRY_ENVIRONMENT=development # デフォルト: development（例: development, staging, production）
+```
+
+##### テスト専用の環境変数
+
+テスト実行時のみ必要な環境変数です。
+
+```bash
+# テスト用ローカルMySQL接続情報
+export TEST_DATABASE_PASSWORD=       # テスト用DBユーザーパスワード
+export TEST_DATABASE_ROOT_PASSWORD=  # テスト用DBルートパスワード（Docker Compose使用時）
+
+# PlanetScale API設定（テスト用）
+export PLANETSCALE_ORG_NAME=         # PlanetScale組織名
+export PLANETSCALE_SERVICE_TOKEN_ID= # PlanetScaleサービストークンID
+export PLANETSCALE_SERVICE_TOKEN=    # PlanetScaleサービストークン
+export PLANETSCALE_DATABASE_NAME=    # PlanetScaleデータベース名
+export PLANETSCALE_BRANCH_NAME=      # PlanetScaleブランチ名
 ```
 
 **注意**: `.envrc` ファイルは `.gitignore` に含まれているため、リポジトリにコミットされません。

--- a/src/config.py
+++ b/src/config.py
@@ -78,6 +78,26 @@ def get_upload_s3_bucket_name() -> str:
     return UPLOAD_S3_BUCKET_NAME
 
 
+def get_aws_bedrock_region() -> str:
+    return AWS_BEDROCK_REGION
+
+
+def get_aws_bedrock_embedding_model_id() -> str:
+    return AWS_BEDROCK_EMBEDDING_MODEL_ID
+
+
+def get_s3_vector_region() -> str:
+    return S3_VECTOR_REGION
+
+
+def get_s3_vector_bucket_name() -> str:
+    return S3_VECTOR_BUCKET_NAME
+
+
+def get_s3_vector_index_name() -> str:
+    return S3_VECTOR_INDEX_NAME
+
+
 def get_log_level() -> str:
     return LOG_LEVEL
 

--- a/src/infrastructure/bedrock_client.py
+++ b/src/infrastructure/bedrock_client.py
@@ -39,6 +39,8 @@ class BedrockClient:
                     contentType="application/json",
                     accept="application/json",
                 )
+                # async withブロックの中でresponse bodyを読み取る
+                response_body = json.loads(await response["body"].read())
         except (ClientError, BotoCoreError) as e:
             # ClientErrorの場合はerror_codeを取得、BotoCoreErrorの場合はNone
             error_code = getattr(e, "response", {}).get("Error", {}).get("Code")
@@ -67,7 +69,6 @@ class BedrockClient:
                 f"Failed to invoke Bedrock model: {type(e).__name__}"
             ) from e
 
-        response_body = json.loads(response["body"].read())
         # embedding_typesを指定した場合のレスポンス形式:
         # {"embeddings": {"float": [[float, float, ...]]}}
         embeddings_by_type = response_body.get("embeddings", {})

--- a/src/infrastructure/lgtm_image_search_repository.py
+++ b/src/infrastructure/lgtm_image_search_repository.py
@@ -55,7 +55,7 @@ class LgtmImageSearchRepository(LgtmImageSearchRepositoryInterface):
                 )
 
             # 例: "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
-            image_url = f"{self.base_url}/{source_key}"
+            image_url = f"https://{self.base_url}/{source_key}"
 
             # distanceフィールドを厳密に検証
             # S3 Vectorはdistance(距離)を返す(小さいほど類似度が高い)

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -2,12 +2,16 @@
 
 from typing import TYPE_CHECKING
 
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
 from fastapi.responses import JSONResponse
 
 from domain.lgtm_image import LgtmImage
 from domain.lgtm_image_errors import (
     ErrImageFetchFailed,
     ErrInvalidImageExtension,
+    ErrInvalidSearchQuery,
     ErrInvalidUrl,
     ErrRecordCount,
     ErrUrlNotAccessible,
@@ -26,6 +30,7 @@ from presentation.controller.lgtm_image_response import (
     LgtmImageItem,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
+    LgtmImageSearchResponse,
 )
 from presentation.controller.response_helper import (
     create_json_response,
@@ -41,6 +46,7 @@ from usecase.extract_random_lgtm_images_usecase import (
 from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
 )
+from usecase.search_lgtm_images_by_text import SearchLgtmImagesByTextUsecase
 
 if TYPE_CHECKING:
     from domain.repository.image_fetch_repository_interface import (
@@ -185,4 +191,32 @@ class LgtmImageController:
             )
         except Exception as e:
             logger.error(f"Error retrieving recently created LGTM images: {e}")
+            return create_error_response(e)
+
+    @staticmethod
+    async def search_by_text(
+        repository: LgtmImageSearchRepositoryInterface,
+        query: str,
+    ) -> JSONResponse:
+        logger.info("Searching LGTM images by text", extra={"query_length": len(query)})
+
+        try:
+            results = await SearchLgtmImagesByTextUsecase.execute(repository, query)
+
+            # ドメインエンティティをレスポンスモデルに変換（順序を保持）
+            image_items = [
+                LgtmImageItem(id=result["id"], url=result["url"])  # type: ignore[arg-type]
+                for result in results
+            ]
+
+            response = LgtmImageSearchResponse(lgtmImages=image_items)
+            return create_json_response(response)
+
+        except ErrInvalidSearchQuery as e:
+            # 空クエリなどのバリデーションエラー
+            logger.error(f"Validation error: {e}")
+            return JSONResponse(status_code=400, content={"error": str(e)})
+        except Exception as e:
+            # その他の予期しないエラー
+            logger.error(f"Error searching LGTM images by text: {e}")
             return create_error_response(e)

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -61,3 +61,23 @@ class LgtmImageCreateFromUrlRequest(BaseModel):
             raise ValueError("image_url must have a valid hostname")
 
         return v
+
+
+class TextSearchRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    query: str = Field(
+        ...,
+        description="検索クエリテキスト",
+        min_length=1,
+        max_length=200,
+        examples=["猫", "おめでとう", "ありがとう"],
+    )
+
+    @field_validator("query")
+    @classmethod
+    def validate_query(cls, v: str) -> str:
+        # 空白のみの文字列をチェック
+        if not v.strip():
+            raise ValueError("検索クエリは空白のみにできません")
+        return v

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -33,3 +33,11 @@ class LgtmImageCreateResponse(BaseModel):
     image_url: HttpUrl = Field(
         ..., alias="imageUrl", description="アップロードされた画像のURL"
     )
+
+
+class LgtmImageSearchResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    lgtm_images: list[LgtmImageItem] = Field(
+        ..., alias="lgtmImages", description="検索結果の画像リスト"
+    )

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -7,20 +7,34 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import (
+    get_aws_bedrock_embedding_model_id,
+    get_aws_bedrock_region,
     get_lgtm_images_base_url,
+    get_s3_vector_bucket_name,
+    get_s3_vector_index_name,
+    get_s3_vector_region,
     get_upload_s3_bucket_name,
 )
 from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
 from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
+from infrastructure.bedrock_client import BedrockClient
 from infrastructure.database import create_db_session
 from infrastructure.lgtm_image_repository import LgtmImageRepository
+from infrastructure.lgtm_image_search_repository import LgtmImageSearchRepository
 from infrastructure.s3_repository import S3Repository
+from infrastructure.s3_vector_client import S3VectorClient
 from presentation.controller.lgtm_image_controller import LgtmImageController
-from presentation.controller.lgtm_image_request import LgtmImageCreateRequest
+from presentation.controller.lgtm_image_request import (
+    LgtmImageCreateRequest,
+    TextSearchRequest,
+)
 from presentation.dependencies.auth import verify_token
 
 router = APIRouter()
@@ -36,6 +50,27 @@ def create_object_storage_repository(
     bucket_name: Annotated[str, Depends(get_upload_s3_bucket_name)],
 ) -> ObjectStorageRepositoryInterface:
     return S3Repository(bucket_name)
+
+
+def create_lgtm_image_search_repository(
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    bedrock_region: Annotated[str, Depends(get_aws_bedrock_region)],
+    bedrock_model_id: Annotated[str, Depends(get_aws_bedrock_embedding_model_id)],
+    s3_vector_region: Annotated[str, Depends(get_s3_vector_region)],
+    s3_vector_bucket_name: Annotated[str, Depends(get_s3_vector_bucket_name)],
+    s3_vector_index_name: Annotated[str, Depends(get_s3_vector_index_name)],
+) -> LgtmImageSearchRepositoryInterface:
+    """LGTM画像検索リポジトリのインスタンスを生成"""
+    bedrock_client = BedrockClient(
+        region=bedrock_region,
+        model_id=bedrock_model_id,
+    )
+    s3_vector_client = S3VectorClient(
+        region=s3_vector_region,
+        bucket_name=s3_vector_bucket_name,
+        index_name=s3_vector_index_name,
+    )
+    return LgtmImageSearchRepository(bedrock_client, s3_vector_client, base_url)
 
 
 @router.post(
@@ -183,3 +218,64 @@ async def retrieve_recently_created_lgtm_images(
     token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.exec_recently_created(repository, base_url)
+
+
+@router.post(
+    "/lgtm-images/search/text",
+    summary="テキストからLGTM画像を検索",
+    description="ユーザーが入力したテキストと関連する画像を検索して返します。最大9件まで返却されます。",
+    response_description="検索結果の画像リスト（関連度の高い順）",
+    tags=["LGTM Images"],
+    responses={
+        200: {
+            "description": "成功時のレスポンス",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "lgtmImages": [
+                            {
+                                "id": "1",
+                                "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                            },
+                            {
+                                "id": "2",
+                                "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                            },
+                        ]
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "バリデーションエラー（空クエリなど）",
+            "content": {
+                "application/json": {
+                    "example": {"error": "検索クエリは空白のみにできません"}
+                }
+            },
+        },
+        401: {
+            "description": "認証エラー",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid authorization header"}
+                }
+            },
+        },
+        500: {
+            "description": "サーバーエラー",
+            "content": {
+                "application/json": {"example": {"error": "Internal server error"}}
+            },
+        },
+    },
+)
+async def search_lgtm_images_by_text(
+    request_body: TextSearchRequest,
+    repository: Annotated[
+        LgtmImageSearchRepositoryInterface,
+        Depends(create_lgtm_image_search_repository),
+    ],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
+) -> JSONResponse:
+    return await LgtmImageController.search_by_text(repository, request_body.query)

--- a/task-definition-prod.json
+++ b/task-definition-prod.json
@@ -41,6 +41,14 @@
         {
           "name": "SENTRY_ENVIRONMENT",
           "value": "production"
+        },
+        {
+          "name": "S3_VECTOR_BUCKET_NAME",
+          "value": "prod-lgtm-cat-vectors"
+        },
+        {
+          "name": "S3_VECTOR_INDEX_NAME",
+          "value": "prod-multimodal-search-index"
         }
       ],
       "mountPoints": [],

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -41,7 +41,15 @@
         {
           "name": "SENTRY_ENVIRONMENT",
           "value": "staging"
-       }
+        },
+        {
+          "name": "S3_VECTOR_BUCKET_NAME",
+          "value": "stg-lgtm-cat-vectors"
+        },
+        {
+          "name": "S3_VECTOR_INDEX_NAME",
+          "value": "stg-multimodal-search-index"
+        }
       ],
       "mountPoints": [],
       "volumesFrom": [],

--- a/tests/infrastructure/test_bedrock_client.py
+++ b/tests/infrastructure/test_bedrock_client.py
@@ -1,7 +1,6 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
 import json
-from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,8 +26,10 @@ class TestBedrockClient:
         """正常にテキストの埋め込みが生成できることを検証"""
         # モックレスポンスの設定
         response_body = json.dumps(mock_bedrock_response)
+        mock_body = AsyncMock()
+        mock_body.read = AsyncMock(return_value=response_body.encode("utf-8"))
         mock_response = {
-            "body": BytesIO(response_body.encode("utf-8")),
+            "body": mock_body,
         }
 
         # aioboto3のセッションとクライアントをモック
@@ -101,8 +102,10 @@ class TestBedrockClient:
         # モックレスポンスの設定：floatキーがない
         mock_response_data = {"embeddings": {"int8": [[1, 2, 3]]}}  # floatがない
         response_body = json.dumps(mock_response_data)
+        mock_body = AsyncMock()
+        mock_body.read = AsyncMock(return_value=response_body.encode("utf-8"))
         mock_response = {
-            "body": BytesIO(response_body.encode("utf-8")),
+            "body": mock_body,
         }
 
         mock_client = AsyncMock()

--- a/tests/infrastructure/test_lgtm_image_search_repository.py
+++ b/tests/infrastructure/test_lgtm_image_search_repository.py
@@ -44,7 +44,7 @@ class TestLgtmImageSearchRepository:
             ]
         )
 
-        base_url = "https://example.com"
+        base_url = "example.com"
         repository = LgtmImageSearchRepository(
             bedrock_client=mock_bedrock_client,
             s3_vector_client=mock_s3_vector_client,

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -630,3 +630,126 @@ class TestLgtmImageController:
         assert "Internal server error" in content["error"]
 
         mock_storage_repo.upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_success_with_results(self) -> None:
+        """正常系: 検索クエリで複数の結果が返る."""
+        # Arrange
+        query = "cat"
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text = AsyncMock(
+            return_value=[
+                {"id": "1", "url": "https://example.com/lgtm1.webp"},
+                {"id": "2", "url": "https://example.com/lgtm2.webp"},
+                {"id": "3", "url": "https://example.com/lgtm3.webp"},
+            ]
+        )
+
+        # Act
+        result = await LgtmImageController.search_by_text(
+            repository=mock_repository,
+            query=query,
+        )
+
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        # Assert - レスポンス構造を検証
+        content = json.loads(bytes(result.body))
+        assert isinstance(content, dict)
+        assert "lgtmImages" in content
+        assert isinstance(content["lgtmImages"], list)
+        assert len(content["lgtmImages"]) == 3
+
+        # Assert - 各アイテムの構造を検証
+        for item in content["lgtmImages"]:
+            assert "id" in item
+            assert "url" in item
+            assert isinstance(item["id"], str)
+            assert isinstance(item["url"], str)
+
+        # Assert - モックが正しく呼ばれたことを検証
+        mock_repository.search_by_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_success_with_empty_results(self) -> None:
+        """正常系: 検索結果が0件の場合、空の配列を返す."""
+        # Arrange
+        query = "nonexistent"
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text = AsyncMock(return_value=[])
+
+        # Act
+        result = await LgtmImageController.search_by_text(
+            repository=mock_repository,
+            query=query,
+        )
+
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        # Assert - レスポンス構造を検証
+        content = json.loads(bytes(result.body))
+        assert isinstance(content, dict)
+        assert "lgtmImages" in content
+        assert isinstance(content["lgtmImages"], list)
+        assert len(content["lgtmImages"]) == 0
+
+        # Assert - モックが正しく呼ばれたことを検証
+        mock_repository.search_by_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_raises_error_with_invalid_query(self) -> None:
+        """異常系: ErrInvalidSearchQueryが発生した場合、400エラーを返す."""
+        # Arrange
+        query = ""
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text = AsyncMock(return_value=[])
+
+        # Act
+        result = await LgtmImageController.search_by_text(
+            repository=mock_repository,
+            query=query,
+        )
+
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+        # Assert - エラーメッセージが含まれることを検証
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Search query cannot be empty" in content["error"]
+
+        # Assert - 無効なクエリの場合、リポジトリが呼ばれないことを検証
+        mock_repository.search_by_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_by_text_raises_error_with_unexpected_exception(self) -> None:
+        """異常系: 予期しないエラーの場合、500エラーを返す."""
+        # Arrange
+        query = "cat"
+        mock_repository = AsyncMock()
+        mock_repository.search_by_text = AsyncMock(
+            side_effect=Exception("Unexpected database error")
+        )
+
+        # Act
+        result = await LgtmImageController.search_by_text(
+            repository=mock_repository,
+            query=query,
+        )
+
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+
+        # Assert - エラーメッセージが含まれることを検証
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Internal server error" in content["error"]
+
+        # Assert - モックが正しく呼ばれたことを検証
+        mock_repository.search_by_text.assert_called_once()


### PR DESCRIPTION
# issueURL

#59

# この PR で対応する範囲 / この PR で対応しない範囲

この PR で対応する範囲：
- テキスト検索APIエンドポイント（POST /lgtm-images/search/text）の実装
- AWS Bedrock連携によるテキスト埋め込みとベクトル検索機能
- 環境変数の追加と設定ドキュメントの改善
- ECSタスク定義への環境変数追加

この PR で対応しない範囲：
- なし（#59 はこのPRで全て完了する）

# 変更点概要

テキスト検索機能を実装し、ユーザーが自然言語でLGTM画像を検索できるようにした。

主な変更内容：
- POST /lgtm-images/search/text エンドポイントの追加
- AWS Bedrockを利用したテキスト埋め込み生成機能の実装
- S3 Vectorsとの連携によるベクトル検索機能の実装
- 必須環境変数とオプション環境変数の明確化
- README.mdでの環境変数ドキュメントの改善

動作確認中に見つけた不具合の修正：
- AWS Bedrock APIレスポンスのストリーム読み取りをasync withブロック内で実行するように修正
- テキスト検索APIのレスポンスで画像URLにhttpsスキームを追加

# レビュアーに重点的にチェックして欲しい点

- APIエンドポイントのIFは適切か

エンドポイントを `/lgtm-images/search/text` としているのは、将来的に画像検索のエンドポイント `POST /lgtm-images/search/image` を追加する想定である。