### PR TITLE
APIドキュメントでレスポンスの詳細を表示できるように改善

### DIFF
--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -9,7 +9,7 @@ class LgtmImageItem(BaseModel):
         ...,
         description="LGTM画像のURL",
         examples=[
-            "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
         ],
     )
 
@@ -25,11 +25,11 @@ class LgtmImageRandomListResponse(BaseModel):
             [
                 {
                     "id": "1",
-                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
                 {
                     "id": "2",
-                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
             ]
         ],
@@ -47,11 +47,11 @@ class LgtmImageRecentlyCreatedListResponse(BaseModel):
             [
                 {
                     "id": "1",
-                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
                 {
                     "id": "2",
-                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
             ]
         ],
@@ -82,11 +82,11 @@ class LgtmImageSearchResponse(BaseModel):
             [
                 {
                     "id": "1",
-                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
                 {
                     "id": "2",
-                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                 },
             ]
         ],

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -8,6 +8,9 @@ class LgtmImageItem(BaseModel):
     url: HttpUrl = Field(
         ...,
         description="LGTM画像のURL",
+        examples=[
+            "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+        ],
     )
 
 
@@ -15,7 +18,21 @@ class LgtmImageRandomListResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     lgtm_images: list[LgtmImageItem] = Field(
-        ..., alias="lgtmImages", description="LGTM画像のリスト"
+        ...,
+        alias="lgtmImages",
+        description="LGTM画像のリスト",
+        examples=[
+            [
+                {
+                    "id": "1",
+                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+                {
+                    "id": "2",
+                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+            ]
+        ],
     )
 
 
@@ -23,7 +40,21 @@ class LgtmImageRecentlyCreatedListResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     lgtm_images: list[LgtmImageItem] = Field(
-        ..., alias="lgtmImages", description="最近作成されたLGTM画像のリスト"
+        ...,
+        alias="lgtmImages",
+        description="最近作成されたLGTM画像のリスト",
+        examples=[
+            [
+                {
+                    "id": "1",
+                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+                {
+                    "id": "2",
+                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+            ]
+        ],
     )
 
 
@@ -31,7 +62,12 @@ class LgtmImageCreateResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     image_url: HttpUrl = Field(
-        ..., alias="imageUrl", description="アップロードされた画像のURL"
+        ...,
+        alias="imageUrl",
+        description="アップロードされた画像のURL",
+        examples=[
+            "https://lgtm-images.lgtmeow.com/2024/01/15/14/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+        ],
     )
 
 
@@ -39,5 +75,19 @@ class LgtmImageSearchResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     lgtm_images: list[LgtmImageItem] = Field(
-        ..., alias="lgtmImages", description="検索結果の画像リスト"
+        ...,
+        alias="lgtmImages",
+        description="検索結果の画像リスト",
+        examples=[
+            [
+                {
+                    "id": "1",
+                    "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+                {
+                    "id": "2",
+                    "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                },
+            ]
+        ],
     )

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -151,11 +151,11 @@ async def create_lgtm_image(
                         "lgtmImages": [
                             {
                                 "id": "1",
-                                "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                             {
                                 "id": "2",
-                                "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                         ]
                     }
@@ -198,11 +198,11 @@ async def extract_random_lgtm_images(
                         "lgtmImages": [
                             {
                                 "id": "1",
-                                "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                             {
                                 "id": "2",
-                                "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                         ]
                     }
@@ -245,11 +245,11 @@ async def retrieve_recently_created_lgtm_images(
                         "lgtmImages": [
                             {
                                 "id": "1",
-                                "url": "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                             {
                                 "id": "2",
-                                "url": "https://example.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
                             },
                         ]
                     }

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -4,6 +4,12 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
+from presentation.controller.lgtm_image_response import (
+    LgtmImageCreateResponse,
+    LgtmImageRandomListResponse,
+    LgtmImageRecentlyCreatedListResponse,
+    LgtmImageSearchResponse,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import (
@@ -78,6 +84,7 @@ def create_lgtm_image_search_repository(
     summary="LGTM画像を作成",
     description="base64エンコードされた画像をS3にアップロードし、URLを返します。",
     response_description="アップロードされた画像のURL",
+    response_model=LgtmImageCreateResponse,
     tags=["LGTM Images"],
     status_code=202,
     responses={
@@ -133,6 +140,7 @@ async def create_lgtm_image(
     summary="ランダムなLGTM画像を取得",
     description="ランダムに選択されたLGTM画像のリストを返します。",
     response_description="ランダムに選択されたLGTM画像のリスト",
+    response_model=LgtmImageRandomListResponse,
     tags=["LGTM Images"],
     responses={
         200: {
@@ -179,6 +187,7 @@ async def extract_random_lgtm_images(
     summary="最近作成されたLGTM画像を取得",
     description="最近作成されたLGTM画像のリストを返します。",
     response_description="最近作成されたLGTM画像のリスト",
+    response_model=LgtmImageRecentlyCreatedListResponse,
     tags=["LGTM Images"],
     responses={
         200: {
@@ -224,7 +233,8 @@ async def retrieve_recently_created_lgtm_images(
     "/lgtm-images/search/text",
     summary="テキストからLGTM画像を検索",
     description="ユーザーが入力したテキストと関連する画像を検索して返します。最大9件まで返却されます。",
-    response_description="検索結果の画像リスト（関連度の高い順）",
+    response_description="検索結果の画像リスト(関連度の高い順)",
+    response_model=LgtmImageSearchResponse,
     tags=["LGTM Images"],
     responses={
         200: {

--- a/src/presentation/router/lgtm_image_v2_router.py
+++ b/src/presentation/router/lgtm_image_v2_router.py
@@ -26,6 +26,9 @@ from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
 )
+from presentation.controller.lgtm_image_response import (
+    LgtmImageCreateResponse,
+)
 from presentation.dependencies.auth import verify_token
 
 router = APIRouter()
@@ -52,6 +55,7 @@ def create_object_storage_repository(
     summary="署名付きURLからLGTM画像を作成",
     description="許可された署名付きURLから画像を取得してS3にアップロードし、URLを返します。セキュリティ上、事前に設定されたドメインのURLのみ受け付けます。",
     response_description="アップロードされた画像のURL",
+    response_model=LgtmImageCreateResponse,
     tags=["LGTM Images V2"],
     status_code=202,
     responses={


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/64

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- 全レスポンスモデルのフィールドに`examples`パラメータを追加
- 全エンドポイントに`response_model`パラメータを設定
- APIドキュメントのサンプルURLを実際のドメインに統一

## 対応しない範囲
- 特になし

# 変更点概要

API仕様書(/docs、/redoc)でレスポンスの詳細情報が表示されず、API利用者が実際のレスポンス形式を理解しづらい状態だったため、FastAPIの`response_model`パラメータとPydanticの`Field examples`を活用してOpenAPI仕様書に詳細な型情報とサンプル値が自動生成されるようにした。
また、API利用者が実際のレスポンス形式を理解しやすいように、APIドキュメントのサンプルURLを実際のドメインに統一。

- /redoc
<img width="975" height="712" alt="スクリーンショット 2025-11-18 10 50 17" src="https://github.com/user-attachments/assets/443a1f95-ef62-4054-9b92-08c237f26334" />

- /docs
<img width="969" height="784" alt="スクリーンショット 2025-11-18 11 18 33" src="https://github.com/user-attachments/assets/d85f96bf-6a7a-4bb3-9fbd-778b58487bb2" />

