### PR TITLE
画像類似度検索のリポジトリ層を実装

### DIFF
--- a/src/domain/image_format.py
+++ b/src/domain/image_format.py
@@ -8,6 +8,13 @@ _MIME_TO_EXT = {
     "image/png": ".png",
 }
 
+# 拡張子からMIMEタイプへのマッピング(単一の情報源)
+_EXT_TO_MIME = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+}
+
 # 許可される画像のMIMEタイプ(後方互換性のため_MIME_TO_EXTから派生)
 ALLOWED_IMAGE_MIME_TYPES = list(_MIME_TO_EXT.keys())
 

--- a/src/domain/image_format.py
+++ b/src/domain/image_format.py
@@ -33,3 +33,17 @@ def mime_type_to_extension(mime_type: str) -> str:
         )
 
     return extension
+
+
+def extension_to_mime_type(extension: str) -> str:
+    # 拡張子を正規化(トリム + 小文字化)して大文字小文字を区別しない検索を行う
+    normalized_extension = extension.strip().lower()
+
+    mime_type = _EXT_TO_MIME.get(normalized_extension)
+    if mime_type is None:
+        allowed_exts = " or ".join(sorted(_EXT_TO_MIME.keys()))
+        raise ErrInvalidImageExtension(
+            f"Unsupported image extension: {normalized_extension}. Expected {allowed_exts}"
+        )
+
+    return mime_type

--- a/src/domain/repository/lgtm_image_search_repository_interface.py
+++ b/src/domain/repository/lgtm_image_search_repository_interface.py
@@ -9,3 +9,10 @@ class LgtmImageSearchRepositoryInterface(Protocol):
     async def search_by_text(
         self, query_text: str, max_results: int = DEFAULT_SEARCH_MAX_RESULTS
     ) -> list[LgtmImageSearchResult]: ...
+
+    async def search_by_image(
+        self,
+        image_data: str,
+        image_extension: str,
+        max_results: int = 9,
+    ) -> list[LgtmImageSearchResult]: ...

--- a/src/domain/repository/lgtm_image_search_repository_interface.py
+++ b/src/domain/repository/lgtm_image_search_repository_interface.py
@@ -14,5 +14,5 @@ class LgtmImageSearchRepositoryInterface(Protocol):
         self,
         image_data: str,
         image_extension: str,
-        max_results: int = 9,
+        max_results: int = DEFAULT_SEARCH_MAX_RESULTS,
     ) -> list[LgtmImageSearchResult]: ...

--- a/src/infrastructure/bedrock_client.py
+++ b/src/infrastructure/bedrock_client.py
@@ -5,7 +5,10 @@ import json
 import aioboto3
 
 from domain.image_format import extension_to_mime_type
-from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
+from domain.lgtm_image_errors import (
+    ErrEmbeddingGenerationFailed,
+    ErrInvalidImageExtension,
+)
 
 from botocore.exceptions import BotoCoreError, ClientError
 
@@ -83,7 +86,40 @@ class BedrockClient:
     async def generate_image_embedding(
         self, image_data: str, image_extension: str
     ) -> list[float]:
-        mime_type = extension_to_mime_type(image_extension)
+        """
+        画像からベクトル埋め込みを生成します。
+
+        Args:
+            image_data: base64エンコードされた画像データ
+            image_extension: 画像の拡張子（例: ".jpg", ".jpeg", ".png"）
+                            ※ドット付きで指定する必要があります
+
+        Returns:
+            画像のベクトル埋め込み（float のリスト）
+
+        Raises:
+            ErrEmbeddingGenerationFailed: 以下のいずれかの場合に発生
+                                         - サポート外の拡張子が指定された場合（システム側の設定ミス）
+                                         - Bedrock API呼び出しが失敗した場合
+                                         - レスポンスが不正な場合
+
+        Note:
+            通常、サポート外の拡張子はPydanticバリデーションで事前にチェックされます。
+            このメソッドで拡張子エラーが発生する場合は、バリデーション設定とMIMEマッピングの
+            不整合など、システム側の設定ミスを示しています。
+        """
+        try:
+            mime_type = extension_to_mime_type(image_extension)
+        except ErrInvalidImageExtension as e:
+            # Pydanticバリデーション後にこのエラーが発生するのは異常事態
+            # （バリデーション設定とMIMEマッピングの不整合）
+            logger.error(
+                f"Invalid image extension after validation: {image_extension}. "
+                f"This indicates a configuration mismatch. Error: {e}"
+            )
+            raise ErrEmbeddingGenerationFailed(
+                f"Configuration error: unsupported extension {image_extension} passed validation"
+            ) from e
 
         data_uri = f"data:{mime_type};base64,{image_data}"
 

--- a/src/infrastructure/bedrock_client.py
+++ b/src/infrastructure/bedrock_client.py
@@ -4,8 +4,8 @@ import json
 
 import aioboto3
 
+from domain.image_format import _EXT_TO_MIME
 from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
-
 
 from botocore.exceptions import BotoCoreError, ClientError
 
@@ -20,15 +20,7 @@ class BedrockClient:
         self.model_id = model_id
         self.session = aioboto3.Session()
 
-    async def generate_text_embedding(self, text: str) -> list[float]:
-        body = json.dumps(
-            {
-                "texts": [text],
-                "input_type": "search_query",
-                "embedding_types": ["float"],
-            }
-        )
-
+    async def _invoke_bedrock_model(self, body: str) -> list[float]:
         try:
             async with self.session.client(
                 "bedrock-runtime", region_name=self.region
@@ -77,3 +69,35 @@ class BedrockClient:
             raise ErrEmbeddingGenerationFailed("No float embeddings found in response")
         embeddings: list[float] = float_embeddings[0]
         return embeddings
+
+    async def generate_text_embedding(self, text: str) -> list[float]:
+        body = json.dumps(
+            {
+                "texts": [text],
+                "input_type": "search_query",
+                "embedding_types": ["float"],
+            }
+        )
+        return await self._invoke_bedrock_model(body)
+
+    async def generate_image_embedding(
+        self, image_data: str, image_extension: str
+    ) -> list[float]:
+        ext_lower = image_extension.lower()
+        mime_type = _EXT_TO_MIME.get(ext_lower)
+        if mime_type is None:
+            raise ErrEmbeddingGenerationFailed(
+                f"Unsupported image extension: {image_extension}"
+            )
+
+        data_uri = f"data:{mime_type};base64,{image_data}"
+
+        body = json.dumps(
+            {
+                "images": [data_uri],
+                "input_type": "search_query",
+                "embedding_types": ["float"],
+            }
+        )
+
+        return await self._invoke_bedrock_model(body)

--- a/src/infrastructure/bedrock_client.py
+++ b/src/infrastructure/bedrock_client.py
@@ -4,7 +4,7 @@ import json
 
 import aioboto3
 
-from domain.image_format import _EXT_TO_MIME
+from domain.image_format import extension_to_mime_type
 from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
 
 from botocore.exceptions import BotoCoreError, ClientError
@@ -83,12 +83,7 @@ class BedrockClient:
     async def generate_image_embedding(
         self, image_data: str, image_extension: str
     ) -> list[float]:
-        ext_lower = image_extension.lower()
-        mime_type = _EXT_TO_MIME.get(ext_lower)
-        if mime_type is None:
-            raise ErrEmbeddingGenerationFailed(
-                f"Unsupported image extension: {image_extension}"
-            )
+        mime_type = extension_to_mime_type(image_extension)
 
         data_uri = f"data:{mime_type};base64,{image_data}"
 

--- a/src/infrastructure/lgtm_image_search_repository.py
+++ b/src/infrastructure/lgtm_image_search_repository.py
@@ -1,6 +1,7 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
 import math
+from typing import Any
 
 from domain.lgtm_image_errors import ErrVectorDataCorrupted
 from domain.lgtm_image_search import (
@@ -27,18 +28,12 @@ class LgtmImageSearchRepository(LgtmImageSearchRepositoryInterface):
         self.s3_vector_client = s3_vector_client
         self.base_url = base_url
 
-    async def search_by_text(
-        self, query_text: str, max_results: int = DEFAULT_SEARCH_MAX_RESULTS
+    def _convert_search_results(
+        self, search_results: list[dict[str, Any]]
     ) -> list[LgtmImageSearchResult]:
-        query_vector = await self.bedrock_client.generate_text_embedding(query_text)
-
-        search_results = await self.s3_vector_client.search_similar_vectors(
-            query_vector, max_results
-        )
-
         results: list[LgtmImageSearchResult] = []
         for result in search_results:
-            # key にはDB IDが格納されている - まず存在をチェック
+            # keyにはDB IDが格納されている - まず存在をチェック
             image_id = result.get("key")
             if not image_id:
                 raise ErrVectorDataCorrupted(
@@ -98,3 +93,30 @@ class LgtmImageSearchRepository(LgtmImageSearchRepositoryInterface):
             )
 
         return results
+
+    async def search_by_text(
+        self, query_text: str, max_results: int = DEFAULT_SEARCH_MAX_RESULTS
+    ) -> list[LgtmImageSearchResult]:
+        query_vector = await self.bedrock_client.generate_text_embedding(query_text)
+
+        search_results = await self.s3_vector_client.search_similar_vectors(
+            query_vector, max_results
+        )
+
+        return self._convert_search_results(search_results)
+
+    async def search_by_image(
+        self,
+        image_data: str,
+        image_extension: str,
+        max_results: int = DEFAULT_SEARCH_MAX_RESULTS,
+    ) -> list[LgtmImageSearchResult]:
+        query_vector = await self.bedrock_client.generate_image_embedding(
+            image_data, image_extension
+        )
+
+        search_results = await self.s3_vector_client.search_similar_vectors(
+            query_vector, max_results
+        )
+
+        return self._convert_search_results(search_results)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -54,6 +54,77 @@ pytest --cov=src --cov-report=html
 - Ruffのリントとフォーマットに準拠
 - `make lint`と`make format`を通過する必要がある
 
+## テストコード作成時のパターン
+
+### パラメータライズテストの活用
+
+類似した複数のテストケースがある場合は、個別のテストメソッドではなく `@pytest.mark.parametrize` を使用したパラメータライズテストとして実装してください。
+
+**必須**: `ids` パラメータを指定して、テスト結果を読みやすくすること。
+
+**推奨パターン**:
+```python
+@pytest.mark.parametrize(
+    ("extension", "expected_mime_type"),
+    [
+        (".jpg", "image/jpeg"),
+        (".jpeg", "image/jpeg"),
+        (".png", "image/png"),
+    ],
+    ids=["jpg", "jpeg", "png"],  # 必須: テスト結果を読みやすくする
+)
+def test_convert_extension_to_mime_type(
+    self, extension: str, expected_mime_type: str
+) -> None:
+    """拡張子を正しいMIMEタイプに変換する."""
+    result = extension_to_mime_type(extension)
+    assert result == expected_mime_type
+```
+
+**ids命名ルール**:
+- 簡潔でテストケースの内容がわかる名前を使用
+- 特殊文字を含む場合は、わかりやすい別名を使用（例: `"  .jpg  "` → `"jpg_with_spaces"`）
+- 英数字とアンダースコアを推奨
+
+**避けるべきパターン**:
+```python
+# ❌ idsなし（テスト結果が読みにくい）
+@pytest.mark.parametrize(
+    ("extension", "expected_mime_type"),
+    [
+        (".jpg", "image/jpeg"),
+        (".jpeg", "image/jpeg"),
+    ],
+)
+
+# ❌ 個別のテストメソッド（重複が多い）
+def test_convert_jpg_extension(self) -> None:
+    result = extension_to_mime_type(".jpg")
+    assert result == "image/jpeg"
+
+def test_convert_jpeg_extension(self) -> None:
+    result = extension_to_mime_type(".jpeg")
+    assert result == "image/jpeg"
+```
+
+**テスト結果の比較**:
+```
+# idsあり（読みやすい）
+test_convert_extension_to_mime_type[jpg] PASSED
+test_convert_extension_to_mime_type[jpeg] PASSED
+
+# idsなし（読みにくい）
+test_convert_extension_to_mime_type[.jpg-image/jpeg] PASSED
+test_convert_extension_to_mime_type[.jpeg-image/jpeg] PASSED
+```
+
+**メリット**:
+- テストコードの重複を削減
+- 新しいテストケースの追加が容易
+- テストの意図が明確になる
+- テスト結果で各パラメータの組み合わせが読みやすく表示される
+- テスト失敗時にどのケースが失敗したか即座に把握できる
+
 ## データベーステスト
 
 ### test_db_session フィクスチャの使用

--- a/tests/domain/test_image_format.py
+++ b/tests/domain/test_image_format.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from domain.image_format import mime_type_to_extension
+from domain.image_format import extension_to_mime_type, mime_type_to_extension
 from domain.lgtm_image_errors import ErrInvalidImageExtension
 
 
@@ -71,3 +71,76 @@ class TestMimeTypeToExtension:
 
         # Assert
         assert result == ".png"
+
+
+class TestExtensionToMimeType:
+    @pytest.mark.parametrize(
+        ("extension", "expected_mime_type"),
+        [
+            (".jpg", "image/jpeg"),
+            (".jpeg", "image/jpeg"),
+            (".png", "image/png"),
+        ],
+        ids=["jpg", "jpeg", "png"],
+    )
+    def test_convert_extension_to_mime_type(
+        self, extension: str, expected_mime_type: str
+    ) -> None:
+        """拡張子を正しいMIMEタイプに変換する."""
+        # Act
+        result = extension_to_mime_type(extension)
+
+        # Assert
+        assert result == expected_mime_type
+
+    @pytest.mark.parametrize(
+        "extension",
+        [".webp", ".pdf", ".gif", ".bmp"],
+        ids=["webp", "pdf", "gif", "bmp"],
+    )
+    def test_raises_error_for_unsupported_extension(self, extension: str) -> None:
+        """サポートされていない拡張子の場合、エラーを発生させる."""
+        # Act & Assert
+        with pytest.raises(ErrInvalidImageExtension) as exc_info:
+            extension_to_mime_type(extension)
+
+        assert "Unsupported image extension" in str(exc_info.value)
+        assert extension in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        ("extension", "expected_mime_type"),
+        [
+            (".JPG", "image/jpeg"),
+            (".Png", "image/png"),
+            (".JPEG", "image/jpeg"),
+        ],
+        ids=["JPG", "Png", "JPEG"],
+    )
+    def test_convert_uppercase_extension(
+        self, extension: str, expected_mime_type: str
+    ) -> None:
+        """大文字の拡張子も正しく変換される(大文字小文字を区別しない)."""
+        # Act
+        result = extension_to_mime_type(extension)
+
+        # Assert
+        assert result == expected_mime_type
+
+    @pytest.mark.parametrize(
+        ("extension", "expected_mime_type"),
+        [
+            ("  .jpg  ", "image/jpeg"),
+            ("  .PNG  ", "image/png"),
+            ("  .jpeg  ", "image/jpeg"),
+        ],
+        ids=["jpg_with_spaces", "PNG_with_spaces", "jpeg_with_spaces"],
+    )
+    def test_convert_extension_with_whitespace(
+        self, extension: str, expected_mime_type: str
+    ) -> None:
+        """前後に空白を含む拡張子も正しく変換される(トリム処理)."""
+        # Act
+        result = extension_to_mime_type(extension)
+
+        # Assert
+        assert result == expected_mime_type

--- a/tests/infrastructure/test_bedrock_client.py
+++ b/tests/infrastructure/test_bedrock_client.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from domain.lgtm_image_errors import ErrEmbeddingGenerationFailed
 from infrastructure.bedrock_client import BedrockClient
@@ -122,5 +123,123 @@ class TestBedrockClient:
         # テスト実行と検証
         with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
             await bedrock_client.generate_text_embedding("test query")
+
+        assert "No float embeddings found in response" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_image_embedding_success(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """正常に画像の埋め込みが生成できることを検証"""
+        # モックレスポンスの設定（embedding_types指定時の形式）
+        mock_response_data = {"embeddings": {"float": [[0.1, 0.2, 0.3, 0.4, 0.5]]}}
+        response_body = json.dumps(mock_response_data)
+        mock_body = AsyncMock()
+        mock_body.read = AsyncMock(return_value=response_body.encode("utf-8"))
+        mock_response = {
+            "body": mock_body,
+        }
+
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行
+        test_image_data = "base64encodedimagedata"
+        result = await bedrock_client.generate_image_embedding(test_image_data, ".png")
+
+        # 検証
+        assert result == [0.1, 0.2, 0.3, 0.4, 0.5]
+        mock_client.invoke_model.assert_called_once()
+
+        # invoke_modelの引数を検証
+        call_args = mock_client.invoke_model.call_args
+        assert call_args[1]["modelId"] == "cohere.embed-v4:0"
+        assert call_args[1]["contentType"] == "application/json"
+        assert call_args[1]["accept"] == "application/json"
+
+        # リクエストボディの検証
+        request_body = json.loads(call_args[1]["body"])
+        assert request_body["images"] == [
+            "data:image/png;base64,base64encodedimagedata"
+        ]
+        assert request_body["input_type"] == "search_query"
+        assert request_body["embedding_types"] == ["float"]
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_image_embedding_api_error(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """Bedrock API呼び出しエラー時の処理を検証"""
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(
+            side_effect=ClientError(
+                {"Error": {"Code": "ValidationException", "Message": "Invalid input"}},
+                "InvokeModel",
+            )
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行と検証
+        with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
+            await bedrock_client.generate_image_embedding(
+                "base64encodedimagedata", ".png"
+            )
+
+        assert "Failed to invoke Bedrock model" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("infrastructure.bedrock_client.aioboto3.Session")
+    async def test_generate_image_embedding_no_embedding(
+        self,
+        mock_session_class: MagicMock,
+    ) -> None:
+        """レスポンスに埋め込みが含まれていない場合のエラー処理を検証"""
+        # モックレスポンスの設定（floatキーがない）
+        mock_response_data = {"embeddings": {"int8": [[1, 2, 3]]}}
+        response_body = json.dumps(mock_response_data)
+        mock_body = AsyncMock()
+        mock_body.read = AsyncMock(return_value=response_body.encode("utf-8"))
+        mock_response = {
+            "body": mock_body,
+        }
+
+        # aioboto3のセッションとクライアントをモック
+        mock_client = AsyncMock()
+        mock_client.invoke_model = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+        mock_session_class.return_value = mock_session
+
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # テスト実行と検証
+        with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
+            await bedrock_client.generate_image_embedding(
+                "base64encodedimagedata", ".png"
+            )
 
         assert "No float embeddings found in response" in str(exc_info.value)

--- a/tests/infrastructure/test_bedrock_client.py
+++ b/tests/infrastructure/test_bedrock_client.py
@@ -243,3 +243,24 @@ class TestBedrockClient:
             )
 
         assert "No float embeddings found in response" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_generate_image_embedding_invalid_extension(self) -> None:
+        """サポート外の拡張子が指定された場合、ErrEmbeddingGenerationFailedが発生することを検証
+
+        Note:
+            通常、サポート外の拡張子はPydanticバリデーションで事前にチェックされます。
+            このテストは、バリデーション設定とMIMEマッピングの不整合がある場合に
+            適切にエラーハンドリングされることを確認します。
+        """
+        bedrock_client = BedrockClient(region="us-east-1", model_id="cohere.embed-v4:0")
+
+        # サポート外の拡張子でテスト実行
+        with pytest.raises(ErrEmbeddingGenerationFailed) as exc_info:
+            await bedrock_client.generate_image_embedding(
+                "base64encodedimagedata", ".webp"
+            )
+
+        # エラーメッセージに設定エラーであることが含まれていることを確認
+        assert "Configuration error" in str(exc_info.value)
+        assert ".webp" in str(exc_info.value)

--- a/tests/infrastructure/test_lgtm_image_search_repository.py
+++ b/tests/infrastructure/test_lgtm_image_search_repository.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from domain.lgtm_image_errors import ErrVectorDataCorrupted
+from domain.lgtm_image_errors import (
+    ErrEmbeddingGenerationFailed,
+    ErrVectorDataCorrupted,
+)
 from infrastructure.lgtm_image_search_repository import (
     LgtmImageSearchRepository,
 )
@@ -334,6 +337,354 @@ class TestLgtmImageSearchRepository:
         # テスト実行: 例外が投げられることを検証
         with pytest.raises(ErrVectorDataCorrupted) as exc_info:
             await repository.search_by_text("test query", max_results=9)
+
+        # エラーメッセージの確認
+        assert "Vector data missing required 'key' field" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_success(self) -> None:
+        """正常に画像検索が実行できることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：画像埋め込みベクトルを返す
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：検索結果を返す（source_key含む）
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "123",
+                    "distance": 0.15,
+                    "metadata": {
+                        "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+                    },
+                },
+                {
+                    "key": "456",
+                    "distance": 0.25,
+                    "metadata": {
+                        "source_key": "2021/03/17/12/6947f291-a46e-453c-a230-0d756d7174cc.webp"
+                    },
+                },
+            ]
+        )
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行
+        test_image_data = "base64encodedimagedata"
+        results = await repository.search_by_image(
+            test_image_data, ".png", max_results=9
+        )
+
+        # 検証
+        assert len(results) == 2
+
+        # 1件目の検証
+        assert results[0]["id"] == "123"
+        assert (
+            results[0]["url"]
+            == "https://example.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+        )
+        # distance=0.15 -> similarity_score=1.0/(1.0+0.15)≒0.8696
+        assert results[0]["similarity_score"] == pytest.approx(1.0 / 1.15)
+
+        # 2件目の検証
+        assert results[1]["id"] == "456"
+        assert (
+            results[1]["url"]
+            == "https://example.com/2021/03/17/12/6947f291-a46e-453c-a230-0d756d7174cc.webp"
+        )
+        # distance=0.25 -> similarity_score=1.0/(1.0+0.25)=0.8
+        assert results[1]["similarity_score"] == pytest.approx(0.8)
+
+        # モックメソッドの呼び出しを検証
+        mock_bedrock_client.generate_image_embedding.assert_called_once_with(
+            test_image_data, ".png"
+        )
+        mock_s3_vector_client.search_similar_vectors.assert_called_once_with(
+            [0.1, 0.2, 0.3, 0.4, 0.5], 9
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_empty_result(self) -> None:
+        """画像検索で結果が0件の場合を検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：画像埋め込みベクトルを返す
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：空の結果を返す
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(return_value=[])
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行
+        results = await repository.search_by_image(
+            "base64encodedimagedata", ".png", max_results=9
+        )
+
+        # 検証
+        assert len(results) == 0
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_bedrock_error(self) -> None:
+        """BedrockClientでエラーが発生した場合を検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：エラーを発生させる
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            side_effect=ErrEmbeddingGenerationFailed("Bedrock API error")
+        )
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(ErrEmbeddingGenerationFailed):
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_s3_vector_error(self) -> None:
+        """S3 Vector検索でエラーが発生した場合を検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：画像埋め込みベクトルを返す
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：エラーを発生させる
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            side_effect=Exception("S3 Vector API error")
+        )
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(Exception) as exc_info:
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
+        assert "S3 Vector API error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_raises_error_when_source_key_missing(self) -> None:
+        """metadataにsource_keyが含まれていない場合のエラー処理を検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：画像埋め込みベクトルを返す
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：source_keyが欠落している結果を返す
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "123",
+                    "distance": 0.15,
+                    "metadata": {},  # source_keyがない
+                }
+            ]
+        )
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
+        assert "missing required 'source_key' in metadata" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_raises_error_when_metadata_missing(self) -> None:
+        """メタデータ自体がない場合、ErrVectorDataCorruptedが発生することを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        # BedrockClientのモック：画像埋め込みベクトルを返す
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # S3VectorClientのモック：メタデータがない結果を返す
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[
+                {
+                    "key": "456",
+                    "distance": 0.1,
+                    # metadataキー自体がない
+                }
+            ]
+        )
+
+        base_url = "example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行と検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
+
+        assert "Vector data missing required 'source_key'" in str(exc_info.value)
+        assert "456" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("distance_value", "expected_error_msg"),
+        [
+            (None, "Vector data missing 'distance' field for id: 123"),
+            ("invalid", "Vector data has non-numeric distance for id: 123"),
+            (-0.5, "Vector data has negative distance for id: 123"),
+            (
+                float("nan"),
+                "Vector data has non-finite distance (NaN or inf) for id: 123",
+            ),
+            (
+                float("inf"),
+                "Vector data has non-finite distance (NaN or inf) for id: 123",
+            ),
+        ],
+        ids=["missing", "non_numeric", "negative", "nan", "inf"],
+    )
+    async def test_search_by_image_raises_error_on_invalid_distance(
+        self,
+        distance_value: Any,
+        expected_error_msg: str,
+    ) -> None:
+        """distanceフィールドが不正な値の場合、ErrVectorDataCorruptedを投げることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # テストケースに応じた結果データを構築
+        result_data: dict[str, Any] = {
+            "key": "123",
+            "metadata": {
+                "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            },
+        }
+        if distance_value is not None:
+            result_data["distance"] = distance_value
+
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[result_data]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行: 例外が投げられることを検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
+
+        # エラーメッセージの確認
+        assert expected_error_msg in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "key_value",
+        [None, ""],
+        ids=["missing", "empty_string"],
+    )
+    async def test_search_by_image_raises_error_on_invalid_key(
+        self,
+        key_value: Any,
+    ) -> None:
+        """keyフィールドが不正な値の場合、ErrVectorDataCorruptedを投げることを検証"""
+        # モックの設定
+        mock_bedrock_client = MagicMock()
+        mock_s3_vector_client = MagicMock()
+
+        mock_bedrock_client.generate_image_embedding = AsyncMock(
+            return_value=[0.1, 0.2, 0.3, 0.4, 0.5]
+        )
+
+        # テストケースに応じた結果データを構築
+        result_data: dict[str, Any] = {
+            "distance": 0.15,
+            "metadata": {
+                "source_key": "2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+            },
+        }
+        if key_value is not None:
+            result_data["key"] = key_value
+
+        mock_s3_vector_client.search_similar_vectors = AsyncMock(
+            return_value=[result_data]
+        )
+
+        base_url = "https://example.com"
+        repository = LgtmImageSearchRepository(
+            bedrock_client=mock_bedrock_client,
+            s3_vector_client=mock_s3_vector_client,
+            base_url=base_url,
+        )
+
+        # テスト実行: 例外が投げられることを検証
+        with pytest.raises(ErrVectorDataCorrupted) as exc_info:
+            await repository.search_by_image(
+                "base64encodedimagedata", ".png", max_results=9
+            )
 
         # エラーメッセージの確認
         assert "Vector data missing required 'key' field" in str(exc_info.value)


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/63

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- 画像埋め込みベクトル生成機能の実装（BedrockClient）
- 画像による類似度検索機能の実装（LgtmImageSearchRepository）
- 拡張子からMIMEタイプへの変換マッピングの追加
- リポジトリインターフェースへの`search_by_image`メソッド定義追加

**対応しない範囲:**
- APIエンドポイント層（ユースケース、コントローラー、ルーター）の実装は別PRで対応する

# 変更点概要

画像類似度検索機能のリポジトリ層を実装した。ユーザーがアップロードした画像と類似するLGTM画像を検索するため、AWS BedrockのCohere Embed Multimodal v4モデルを使用して画像の埋め込みベクトルを生成し、S3 Vectorで類似度検索を行う基盤を整備した。

## 主な変更内容

### 1. BedrockClient の拡張
- `generate_image_embedding`メソッドを追加し、画像データ（base64）から埋め込みベクトルを生成
- 既存の`generate_text_embedding`との共通処理を`_invoke_bedrock_model`メソッドに抽出してリファクタリング
- 画像データをData URI形式（`data:image/png;base64,...`）に変換してBedrockに送信

### 2. LgtmImageSearchRepository の拡張
- `search_by_image`メソッドを実装し、画像ベースの類似度検索に対応
- 既存の`search_by_text`と検索結果の変換処理を共通化（`_convert_search_results`メソッド）
- 類似度スコアの計算ロジックは既存のテキスト検索と同様（`1.0 / (1.0 + distance)`）

### 3. ドメイン層の拡張
- `image_format.py`に拡張子→MIMEタイプのマッピング（`_EXT_TO_MIME`）を追加
- リポジトリインターフェースに`search_by_image`メソッドのプロトコル定義を追加

### 4. テストの追加
- `test_bedrock_client.py`に画像埋め込み生成のテストケースを追加（正常系、エラー系）
- `test_lgtm_image_search_repository.py`に画像検索のテストケースを追加（正常系、エラー系、エッジケース）

## 技術的な判断

- 画像フォーマットのサポート範囲は既存の許可リスト（JPEG、PNG）に準拠
- エラーハンドリングは既存のテキスト検索と同様の設計（`ErrEmbeddingGenerationFailed`、`ErrVectorDataCorrupted`）
- テストカバレッジは既存のテキスト検索と同等レベルを維持