### PR TITLE
類似画像検索APIのユースケース層とプレゼンテーション層を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ APIはシンプルなRESTパターンに従い、3つのエンドポイントを
 2. **POST /lgtm-images** - 新しいLGTM画像を作成（base64画像と拡張子を受け取る）
 3. **GET /lgtm-images/recently-created** - 最近作成されたLGTM画像を返す
 4. **POST /lgtm-images/search/text** - テキストからLGTM画像を検索
+5. **POST /lgtm-images/search/image** - 画像から類似したLGTM画像を検索
 
 レスポンスモデルはPydanticのBaseModelを使用して定義されており、JSONフィールドにはキャメルケースを使用します（例: `imageUrl`, `imageExtension`）。
 

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -1,5 +1,6 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
+from pydantic import HttpUrl
 from typing import TYPE_CHECKING
 
 from domain.repository.lgtm_image_search_repository_interface import (
@@ -24,12 +25,15 @@ from log.url_sanitizer import sanitize_url_for_logging
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageRequest,
 )
 from presentation.controller.lgtm_image_response import (
     LgtmImageCreateResponse,
     LgtmImageItem,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
+    LgtmImageSearchByImageResponse,
+    LgtmImageSearchItem,
     LgtmImageSearchResponse,
 )
 from presentation.controller.response_helper import (
@@ -46,6 +50,7 @@ from usecase.extract_random_lgtm_images_usecase import (
 from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
 )
+from usecase.search_lgtm_images_by_image import SearchLgtmImagesByImageUsecase
 from usecase.search_lgtm_images_by_text import SearchLgtmImagesByTextUsecase
 
 if TYPE_CHECKING:
@@ -219,4 +224,39 @@ class LgtmImageController:
         except Exception as e:
             # その他の予期しないエラー
             logger.error(f"Error searching LGTM images by text: {e}")
+            return create_error_response(e)
+
+    @staticmethod
+    async def search_by_image(
+        repository: LgtmImageSearchRepositoryInterface,
+        request: LgtmImageSearchByImageRequest,
+    ) -> JSONResponse:
+        logger.info(
+            "Searching LGTM images by image",
+            extra={"image_extension": request.image_extension},
+        )
+
+        try:
+            # ユースケース実行
+            similar_images = await SearchLgtmImagesByImageUsecase.execute(
+                repository, request.image, request.image_extension
+            )
+
+            # レスポンスモデルに変換
+            image_items = [
+                LgtmImageSearchItem(
+                    id=img["id"],
+                    url=HttpUrl(img["url"]),
+                    similarityScore=img["similarity_score"],
+                )
+                for img in similar_images
+            ]
+            response = LgtmImageSearchByImageResponse(lgtmImages=image_items)
+
+            # JSONResponse返却
+            return create_json_response(response)
+
+        except Exception as e:
+            # エラーハンドリング
+            logger.error(f"Error searching LGTM images by image: {e}")
             return create_error_response(e)

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -1,6 +1,5 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
-from pydantic import HttpUrl
 from typing import TYPE_CHECKING
 
 from domain.repository.lgtm_image_search_repository_interface import (
@@ -246,7 +245,7 @@ class LgtmImageController:
             image_items = [
                 LgtmImageSearchItem(
                     id=img["id"],
-                    url=HttpUrl(img["url"]),
+                    url=img["url"],  # type: ignore[arg-type]
                     similarityScore=img["similarity_score"],
                 )
                 for img in similar_images

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -81,3 +81,26 @@ class TextSearchRequest(BaseModel):
         if not v.strip():
             raise ValueError("検索クエリは空白のみにできません")
         return v
+
+
+class LgtmImageSearchByImageRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    image: str = Field(
+        ...,
+        description="base64エンコードされた画像データ",
+        examples=["iVBORw0KGgoAAAANSUhEUgAAAAUA..."],
+    )
+    image_extension: str = Field(
+        ...,
+        alias="imageExtension",
+        description="画像拡張子",
+        examples=[".png", ".jpg", ".jpeg"],
+    )
+
+    @field_validator("image_extension")
+    @classmethod
+    def validate_image_extension(cls, v: str) -> str:
+        if not can_convert_image_extension(v):
+            raise ValueError(f"Invalid image extension: {v}")
+        return v

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -91,3 +91,44 @@ class LgtmImageSearchResponse(BaseModel):
             ]
         ],
     )
+
+
+class LgtmImageSearchItem(BaseModel):
+    id: str = Field(..., description="画像ID", examples=["1"])
+    url: HttpUrl = Field(
+        ...,
+        description="画像URL",
+        examples=[
+            "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp"
+        ],
+    )
+    similarity_score: float = Field(
+        ...,
+        alias="similarityScore",
+        description="類似度スコア（0.0〜1.0）",
+        examples=[0.95],
+    )
+
+
+class LgtmImageSearchByImageResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    lgtm_images: list[LgtmImageSearchItem] = Field(
+        ...,
+        alias="lgtmImages",
+        description="類似画像検索結果のリスト",
+        examples=[
+            [
+                {
+                    "id": "1",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "similarityScore": 0.95,
+                },
+                {
+                    "id": "2",
+                    "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "similarityScore": 0.87,
+                },
+            ]
+        ],
+    )

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -8,6 +8,7 @@ from presentation.controller.lgtm_image_response import (
     LgtmImageCreateResponse,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
+    LgtmImageSearchByImageResponse,
     LgtmImageSearchResponse,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,6 +40,7 @@ from infrastructure.s3_vector_client import S3VectorClient
 from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageRequest,
     TextSearchRequest,
 )
 from presentation.dependencies.auth import verify_token
@@ -289,3 +291,76 @@ async def search_lgtm_images_by_text(
     token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.search_by_text(repository, request_body.query)
+
+
+@router.post(
+    "/lgtm-images/search/image",
+    summary="画像から類似したLGTM画像を検索",
+    description="ユーザーから入力された画像と類似する画像を検索して返します。最大9件まで返却されます。",
+    response_description="類似画像検索結果のリスト（類似度の高い順）",
+    response_model=LgtmImageSearchByImageResponse,
+    tags=["LGTM Images"],
+    responses={
+        200: {
+            "description": "成功時のレスポンス",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "lgtmImages": [
+                            {
+                                "id": "1",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.95,
+                            },
+                            {
+                                "id": "2",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.87,
+                            },
+                        ]
+                    }
+                }
+            },
+        },
+        401: {
+            "description": "認証エラー",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid authorization header"}
+                }
+            },
+        },
+        422: {
+            "description": "バリデーションエラー（無効な画像拡張子など）",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": [
+                            {
+                                "type": "value_error",
+                                "loc": ["body", "imageExtension"],
+                                "msg": "Value error, Invalid image extension: .invalid",
+                                "input": ".invalid",
+                            }
+                        ]
+                    }
+                }
+            },
+        },
+        500: {
+            "description": "サーバーエラー",
+            "content": {
+                "application/json": {"example": {"error": "Internal server error"}}
+            },
+        },
+    },
+)
+async def search_by_image(
+    request_body: LgtmImageSearchByImageRequest,
+    repository: Annotated[
+        LgtmImageSearchRepositoryInterface,
+        Depends(create_lgtm_image_search_repository),
+    ],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
+) -> JSONResponse:
+    return await LgtmImageController.search_by_image(repository, request_body)

--- a/src/usecase/search_lgtm_images_by_image.py
+++ b/src/usecase/search_lgtm_images_by_image.py
@@ -1,0 +1,35 @@
+# 絶対厳守:編集前に必ずAI実装ルールを読む
+
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+)
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
+from log.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SearchLgtmImagesByImageUsecase:
+    @staticmethod
+    async def execute(
+        repository: LgtmImageSearchRepositoryInterface,
+        image_data: str,
+        image_extension: str,
+    ) -> list[LgtmImageSearchResult]:
+        logger.info("Executing SearchLgtmImagesByImageUsecase")
+
+        results = await repository.search_by_image(
+            image_data=image_data,
+            image_extension=image_extension,
+            max_results=DEFAULT_SEARCH_MAX_RESULTS,
+        )
+
+        logger.info(
+            "SearchLgtmImagesByImageUsecase completed successfully",
+            extra={"results_count": len(results)},
+        )
+
+        return results

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -15,6 +15,7 @@ from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageRequest,
 )
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images
 
@@ -753,3 +754,115 @@ class TestLgtmImageController:
 
         # Assert - モックが正しく呼ばれたことを検証
         mock_repository.search_by_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_success_with_results(self) -> None:
+        """正常系: 類似画像検索で複数の結果が返る."""
+        # Arrange
+        mock_request = LgtmImageSearchByImageRequest(
+            image="base64encodedimagedata", imageExtension=".png"
+        )
+        mock_repository = AsyncMock()
+        mock_repository.search_by_image = AsyncMock(
+            return_value=[
+                {
+                    "id": "1",
+                    "url": "https://example.com/lgtm1.webp",
+                    "similarity_score": 0.95,
+                },
+                {
+                    "id": "2",
+                    "url": "https://example.com/lgtm2.webp",
+                    "similarity_score": 0.87,
+                },
+                {
+                    "id": "3",
+                    "url": "https://example.com/lgtm3.webp",
+                    "similarity_score": 0.75,
+                },
+            ]
+        )
+
+        # Act
+        result = await LgtmImageController.search_by_image(
+            repository=mock_repository,
+            request=mock_request,
+        )
+
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        # Assert - レスポンス構造を検証
+        content = json.loads(bytes(result.body))
+        assert isinstance(content, dict)
+        assert "lgtmImages" in content
+        assert isinstance(content["lgtmImages"], list)
+        assert len(content["lgtmImages"]) == 3
+
+        # Assert - 各アイテムの構造を検証（類似度スコア付き）
+        for item in content["lgtmImages"]:
+            assert "id" in item
+            assert "url" in item
+            assert "similarityScore" in item
+            assert isinstance(item["id"], str)
+            assert isinstance(item["url"], str)
+            assert isinstance(item["similarityScore"], (int, float))
+
+        # Assert - モックが正しく呼ばれたことを検証
+        mock_repository.search_by_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_success_with_empty_results(self) -> None:
+        """正常系: 類似画像検索で結果が0件の場合."""
+        # Arrange
+        mock_request = LgtmImageSearchByImageRequest(
+            image="base64encodedimagedata", imageExtension=".jpg"
+        )
+        mock_repository = AsyncMock()
+        mock_repository.search_by_image = AsyncMock(return_value=[])
+
+        # Act
+        result = await LgtmImageController.search_by_image(
+            repository=mock_repository,
+            request=mock_request,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        content = json.loads(bytes(result.body))
+        assert content == {"lgtmImages": []}
+
+        mock_repository.search_by_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_raises_error_with_unexpected_exception(
+        self,
+    ) -> None:
+        """異常系: 予期しないエラーが発生した場合、500エラーを返す."""
+        # Arrange
+        mock_request = LgtmImageSearchByImageRequest(
+            image="base64encodedimagedata", imageExtension=".png"
+        )
+        mock_repository = AsyncMock()
+        mock_repository.search_by_image = AsyncMock(
+            side_effect=Exception("Unexpected database error")
+        )
+
+        # Act
+        result = await LgtmImageController.search_by_image(
+            repository=mock_repository,
+            request=mock_request,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert content["error"] == "Internal server error"
+
+        mock_repository.search_by_image.assert_called_once()

--- a/tests/usecase/test_search_lgtm_images_by_image.py
+++ b/tests/usecase/test_search_lgtm_images_by_image.py
@@ -1,0 +1,131 @@
+# 絶対厳守:編集前に必ずAI実装ルールを読む
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+)
+from usecase.search_lgtm_images_by_image import SearchLgtmImagesByImageUsecase
+
+
+class TestSearchLgtmImagesByImageUsecase:
+    """SearchLgtmImagesByImageUsecaseの統合テスト.
+
+    Repository層で画像のベクトル化と検索を実行し、
+    類似画像のリストが返されることを確認する。
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_valid_image_data(self) -> None:
+        """正常系: 有効な画像データから類似画像が返る."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_results: list[LgtmImageSearchResult] = [
+            {
+                "id": "1",
+                "url": "https://example.com/image1.webp",
+                "similarity_score": 0.95,
+            },
+            {
+                "id": "2",
+                "url": "https://example.com/image2.webp",
+                "similarity_score": 0.87,
+            },
+            {
+                "id": "3",
+                "url": "https://example.com/image3.webp",
+                "similarity_score": 0.75,
+            },
+        ]
+        mock_repository.search_by_image.return_value = mock_results
+
+        image_data = "iVBORw0KGgoAAAANSUhEUgAAAAUA..."
+        image_extension = ".png"
+
+        # Act
+        result = await SearchLgtmImagesByImageUsecase.execute(
+            repository=mock_repository,
+            image_data=image_data,
+            image_extension=image_extension,
+        )
+
+        # Assert
+        assert len(result) == 3
+        assert result == mock_results
+        mock_repository.search_by_image.assert_called_once_with(
+            image_data=image_data,
+            image_extension=image_extension,
+            max_results=DEFAULT_SEARCH_MAX_RESULTS,
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_empty_results(self) -> None:
+        """正常系: 検索結果が0件の場合でも空のリストが返る."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_repository.search_by_image.return_value = []
+
+        image_data = "iVBORw0KGgoAAAANSUhEUgAAAAUA..."
+        image_extension = ".jpg"
+
+        # Act
+        result = await SearchLgtmImagesByImageUsecase.execute(
+            repository=mock_repository,
+            image_data=image_data,
+            image_extension=image_extension,
+        )
+
+        # Assert
+        assert len(result) == 0
+        assert result == []
+        mock_repository.search_by_image.assert_called_once_with(
+            image_data=image_data,
+            image_extension=image_extension,
+            max_results=DEFAULT_SEARCH_MAX_RESULTS,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "image_extension",
+        [
+            ".png",
+            ".jpg",
+            ".jpeg",
+        ],
+        ids=["png", "jpg", "jpeg"],
+    )
+    async def test_execute_success_with_various_extensions(
+        self, image_extension: str
+    ) -> None:
+        """正常系: 各種画像拡張子で正常に動作する."""
+        # Arrange
+        mock_repository = AsyncMock()
+        mock_results: list[LgtmImageSearchResult] = [
+            {
+                "id": "1",
+                "url": "https://example.com/image1.webp",
+                "similarity_score": 0.90,
+            }
+        ]
+        mock_repository.search_by_image.return_value = mock_results
+
+        image_data = "iVBORw0KGgoAAAANSUhEUgAAAAUA..."
+
+        # Act
+        result = await SearchLgtmImagesByImageUsecase.execute(
+            repository=mock_repository,
+            image_data=image_data,
+            image_extension=image_extension,
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result == mock_results
+        mock_repository.search_by_image.assert_called_once_with(
+            image_data=image_data,
+            image_extension=image_extension,
+            max_results=DEFAULT_SEARCH_MAX_RESULTS,
+        )


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/63

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**
- ユーザーから入力された画像と類似する画像を検索するAPIのユースケース層の実装
- 類似画像検索APIのプレゼンテーション層（Router、Controller、Request/Responseモデル）の実装
- 上記実装に対応するテストコードの作成
- この PR により #63 が完了する

**対応しない範囲**
- リポジトリ層（infrastructure層）の実装は別PRで対応済み（#66）

# 変更点概要

ユーザーが入力した画像と類似するLGTM画像を検索するAPIエンドポイント `POST /lgtm-images/search/image` を実装した。

**ユースケース層（`src/usecase/search_lgtm_images_by_image.py`）**
- 画像データからベクトル埋め込みを生成し、リポジトリ層を介して類似画像を検索する処理を実装
- 最大9件の結果を類似度の高い順に返す仕様

**プレゼンテーション層**
- `LgtmImageController.search_by_image()`: 画像検索リクエストを受け取り、ユースケースを実行してレスポンスを返す
- `LgtmImageSearchRequest`: base64エンコードされた画像データと拡張子を受け取るリクエストモデル
- `LgtmImageSearchResponse`: 検索結果をJSON形式で返すレスポンスモデル（id、url、similarityScoreを含む）
- Router定義: `POST /lgtm-images/search/image` エンドポイントの追加

**テスト**
- ユースケース層とコントローラー層の単体テストを追加し、正常系・異常系の動作を検証

# 補足情報

**類似画像検索の仕組みについて**

データベースに保存されているベクトル埋め込みは、LGTMテキストが追加された画像から生成されている。一方、ユーザーが検索に使用する画像はLGTMテキストが追加されていない元画像である。

そのため、同じ元画像を検索した場合でも類似スコアは1.0（完全一致）にはならない。stg環境でのテスト結果では、類似スコアが0.75以上の場合に同じ画像が検索結果に含まれることを確認している。

# レビュアーに重点的にチェックして欲しい点

- 類似画像検索の仕組み（LGTMテキスト追加済み画像と元画像での検索、類似スコアの特性）について問題ないか

