### PR TITLE
テキスト画像検索APIのレスポンスに類似スコアを追加

### DIFF
--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -209,7 +209,11 @@ class LgtmImageController:
 
             # ドメインエンティティをレスポンスモデルに変換（順序を保持）
             image_items = [
-                LgtmImageItem(id=result["id"], url=result["url"])  # type: ignore[arg-type]
+                LgtmImageSearchItem(
+                    id=result["id"],
+                    url=result["url"],  # type: ignore[arg-type]
+                    similarityScore=result["similarity_score"],
+                )
                 for result in results
             ]
 

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -74,7 +74,7 @@ class LgtmImageCreateResponse(BaseModel):
 class LgtmImageSearchResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    lgtm_images: list[LgtmImageItem] = Field(
+    lgtm_images: list["LgtmImageSearchItem"] = Field(
         ...,
         alias="lgtmImages",
         description="検索結果の画像リスト",
@@ -83,10 +83,12 @@ class LgtmImageSearchResponse(BaseModel):
                 {
                     "id": "1",
                     "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "similarityScore": 0.9,
                 },
                 {
                     "id": "2",
                     "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                    "similarityScore": 0.8,
                 },
             ]
         ],

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -248,10 +248,12 @@ async def retrieve_recently_created_lgtm_images(
                             {
                                 "id": "1",
                                 "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.9,
                             },
                             {
                                 "id": "2",
                                 "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.8,
                             },
                         ]
                     }

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -640,9 +640,21 @@ class TestLgtmImageController:
         mock_repository = AsyncMock()
         mock_repository.search_by_text = AsyncMock(
             return_value=[
-                {"id": "1", "url": "https://example.com/lgtm1.webp"},
-                {"id": "2", "url": "https://example.com/lgtm2.webp"},
-                {"id": "3", "url": "https://example.com/lgtm3.webp"},
+                {
+                    "id": "1",
+                    "url": "https://example.com/lgtm1.webp",
+                    "similarity_score": 0.9,
+                },
+                {
+                    "id": "2",
+                    "url": "https://example.com/lgtm2.webp",
+                    "similarity_score": 0.8,
+                },
+                {
+                    "id": "3",
+                    "url": "https://example.com/lgtm3.webp",
+                    "similarity_score": 0.7,
+                },
             ]
         )
 
@@ -667,8 +679,10 @@ class TestLgtmImageController:
         for item in content["lgtmImages"]:
             assert "id" in item
             assert "url" in item
+            assert "similarityScore" in item
             assert isinstance(item["id"], str)
             assert isinstance(item["url"], str)
+            assert isinstance(item["similarityScore"], float)
 
         # Assert - モックが正しく呼ばれたことを検証
         mock_repository.search_by_text.assert_called_once()


### PR DESCRIPTION
# issueURL

#68

# この PR で対応する範囲 / この PR で対応しない範囲

この PR では、テキスト画像検索APIのレスポンスに類似スコア（`similarityScore`）フィールドを追加する。

- 対応する範囲：レスポンスモデルへの`similarityScore`フィールド追加、テストコードの更新
- 対応しない範囲：検索アルゴリズムの変更や他のエンドポイントへの影響

# 変更点概要

テキスト画像検索API（`POST /lgtm-images/search/text`）のレスポンスに、各画像の類似度スコアを表すフィールドを追加した。これにより、クライアント側で検索結果の関連度を把握できるようになる。

<img width="661" height="486" alt="スクリーンショット 2025-11-22 9 43 13" src="https://github.com/user-attachments/assets/a4e57b30-6ca2-42a3-9987-2202fb8ebbb4" />
