### PR TITLE
Pydanticの推奨パターンに従いalias使用方法を最適化

### DIFF
--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -79,7 +79,7 @@ class LgtmImageController:
                 image=request_body.image,
                 image_extension=request_body.image_extension,
             )
-            response = LgtmImageCreateResponse(imageUrl=uploaded_image["url"])  # type: ignore[arg-type]
+            response = LgtmImageCreateResponse(image_url=uploaded_image["url"])  # type: ignore[arg-type]
             return create_json_response(response, status_code=202)
         except ErrInvalidImageExtension as e:
             logger.error(f"Invalid image extension: {e}")
@@ -111,7 +111,7 @@ class LgtmImageController:
                 base_url=base_url,
                 image_url=request_body.image_url,
             )
-            response = LgtmImageCreateResponse(imageUrl=uploaded_image["url"])  # type: ignore[arg-type]
+            response = LgtmImageCreateResponse(image_url=uploaded_image["url"])  # type: ignore[arg-type]
             return create_json_response(response, status_code=202)
         except ErrInvalidUrl as e:
             logger.error(f"Invalid URL provided: {e}")
@@ -156,7 +156,7 @@ class LgtmImageController:
                 LgtmImageItem(id=image["id"], url=image["url"])  # type: ignore[arg-type]
                 for image in images
             ]
-            response = LgtmImageRandomListResponse(lgtmImages=image_items)
+            response = LgtmImageRandomListResponse(lgtm_images=image_items)
             return create_json_response(response)
         except ErrRecordCount:
             logger.error("Insufficient LGTM images available")
@@ -185,7 +185,7 @@ class LgtmImageController:
                 LgtmImageItem(id=image["id"], url=image["url"])  # type: ignore[arg-type]
                 for image in images
             ]
-            response = LgtmImageRecentlyCreatedListResponse(lgtmImages=image_items)
+            response = LgtmImageRecentlyCreatedListResponse(lgtm_images=image_items)
             return create_json_response(response)
         except ErrRecordCount:
             logger.error("Insufficient LGTM images available")
@@ -212,12 +212,12 @@ class LgtmImageController:
                 LgtmImageSearchItem(
                     id=result["id"],
                     url=result["url"],  # type: ignore[arg-type]
-                    similarityScore=result["similarity_score"],
+                    similarity_score=result["similarity_score"],
                 )
                 for result in results
             ]
 
-            response = LgtmImageSearchResponse(lgtmImages=image_items)
+            response = LgtmImageSearchResponse(lgtm_images=image_items)
             return create_json_response(response)
 
         except ErrInvalidSearchQuery as e:
@@ -250,11 +250,11 @@ class LgtmImageController:
                 LgtmImageSearchItem(
                     id=img["id"],
                     url=img["url"],  # type: ignore[arg-type]
-                    similarityScore=img["similarity_score"],
+                    similarity_score=img["similarity_score"],
                 )
                 for img in similar_images
             ]
-            response = LgtmImageSearchByImageResponse(lgtmImages=image_items)
+            response = LgtmImageSearchByImageResponse(lgtm_images=image_items)
 
             # JSONResponse返却
             return create_json_response(response)

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -2,14 +2,12 @@
 
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from domain.create_lgtm_image import can_convert_image_extension
 
 
 class LgtmImageCreateRequest(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     image: str = Field(
         ...,
         description="base64エンコードされた画像データ",
@@ -31,13 +29,11 @@ class LgtmImageCreateRequest(BaseModel):
 
 
 class LgtmImageCreateFromUrlRequest(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     image_url: str = Field(
         ...,
         alias="imageUrl",
         description=(
-            "画像のURL（httpsのみ許可）。"
+            "画像のURL(httpsのみ許可)。"
             "URLの形式・スキームを検証します。"
             "許可ドメインのチェックは infrastructure 層で実施します。"
         ),
@@ -64,8 +60,6 @@ class LgtmImageCreateFromUrlRequest(BaseModel):
 
 
 class TextSearchRequest(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     query: str = Field(
         ...,
         description="検索クエリテキスト",
@@ -84,8 +78,6 @@ class TextSearchRequest(BaseModel):
 
 
 class LgtmImageSearchByImageRequest(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     image: str = Field(
         ...,
         description="base64エンコードされた画像データ",

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -1,6 +1,6 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl
 
 
 class LgtmImageItem(BaseModel):
@@ -15,11 +15,9 @@ class LgtmImageItem(BaseModel):
 
 
 class LgtmImageRandomListResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     lgtm_images: list[LgtmImageItem] = Field(
         ...,
-        alias="lgtmImages",
+        serialization_alias="lgtmImages",
         description="LGTM画像のリスト",
         examples=[
             [
@@ -37,11 +35,9 @@ class LgtmImageRandomListResponse(BaseModel):
 
 
 class LgtmImageRecentlyCreatedListResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     lgtm_images: list[LgtmImageItem] = Field(
         ...,
-        alias="lgtmImages",
+        serialization_alias="lgtmImages",
         description="最近作成されたLGTM画像のリスト",
         examples=[
             [
@@ -59,11 +55,9 @@ class LgtmImageRecentlyCreatedListResponse(BaseModel):
 
 
 class LgtmImageCreateResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     image_url: HttpUrl = Field(
         ...,
-        alias="imageUrl",
+        serialization_alias="imageUrl",
         description="アップロードされた画像のURL",
         examples=[
             "https://lgtm-images.lgtmeow.com/2024/01/15/14/5947f291-a46e-453c-a230-0d756d7174cb.webp"
@@ -72,11 +66,9 @@ class LgtmImageCreateResponse(BaseModel):
 
 
 class LgtmImageSearchResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     lgtm_images: list["LgtmImageSearchItem"] = Field(
         ...,
-        alias="lgtmImages",
+        serialization_alias="lgtmImages",
         description="検索結果の画像リスト",
         examples=[
             [
@@ -106,18 +98,16 @@ class LgtmImageSearchItem(BaseModel):
     )
     similarity_score: float = Field(
         ...,
-        alias="similarityScore",
-        description="類似度スコア（0.0〜1.0）",
+        serialization_alias="similarityScore",
+        description="類似度スコア(0.0〜1.0)",
         examples=[0.95],
     )
 
 
 class LgtmImageSearchByImageResponse(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
     lgtm_images: list[LgtmImageSearchItem] = Field(
         ...,
-        alias="lgtmImages",
+        serialization_alias="lgtmImages",
         description="類似画像検索結果のリスト",
         examples=[
             [


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/69

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**:
- PydanticのField設定において`alias`から`serialization_alias`への移行（レスポンスモデルのみ）
- リクエストモデル・レスポンスモデルの不要な`ConfigDict(populate_by_name=True)`の削除
- コントローラー層でのレスポンスモデル生成時のフィールド名をスネークケースに統一

**対応しない範囲**:
- ドメイン層やインフラ層の変更
- 新規機能の追加

# 変更点概要

Pydantic v2の推奨パターンに従い、レスポンスモデルとリクエストモデルのフィールド定義を最適化した。

**主な変更内容**:

1. **レスポンスモデルの最適化**（`lgtm_image_response.py`）
   - `alias`を`serialization_alias`に変更（出力時のみキャメルケース化）
   - 不要な`ConfigDict(populate_by_name=True)`を削除

2. **リクエストモデルの最適化**（`lgtm_image_request.py`）
   - 不要な`ConfigDict(populate_by_name=True)`を削除

3. **コントローラー層の修正**（`lgtm_image_controller.py`）
   - レスポンスモデル生成時のフィールド名をキャメルケースからスネークケースに変更
   - Pythonコード内では一貫してスネークケースを使用し、JSON出力時のみキャメルケースとなるように統一

**技術的背景**:

Pydantic v2では、フィールド名の変換方法として以下の3つがある。

- `alias`: 入力（リクエスト受信）と出力（レスポンス返却）、およびPythonコード内でのインスタンス化の全てで使用可能
- `validation_alias`: 入力（リクエスト受信）時のみ変換される
- `serialization_alias`: 出力（レスポンス返却）時のみ変換される

**レスポンスモデルで`serialization_alias`を採用した理由**:
Pythonコード内では一貫してスネークケース（`lgtm_images`）で扱い、JSON出力時のみキャメルケース（`lgtmImages`）に変換することで、コードの可読性と保守性が向上する。

**リクエストモデルで`alias`を継続使用する理由**:
`validation_alias`に変更すると、テストコード等でPythonコード内からインスタンス化する際にスネークケース（`image_extension`）を使う必要があるが、その場合Pydanticの検証時に「`imageExtension`フィールドが見つからない」というValidationErrorが発生する。`alias`を使用することで、Pythonコード内とJSON入力の両方でキャメルケースを受け入れることができるため、リクエストモデルでは`alias`を継続使用している。

# 補足情報

**APIの後方互換性**:
この変更はコード内部の表現方法の変更であり、JSONレスポンスのフィールド名は従来通りキャメルケースで出力されるため、API利用者への影響はない。