### PR TITLE
署名付きURLからの類似画像検索機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ APIはシンプルなRESTパターンに従い、3つのエンドポイントを
 3. **GET /lgtm-images/recently-created** - 最近作成されたLGTM画像を返す
 4. **POST /lgtm-images/search/text** - テキストからLGTM画像を検索
 5. **POST /lgtm-images/search/image-from-data** - 画像データから類似したLGTM画像を検索
+6. **POST /lgtm-images/search/image-from-url** - 署名付きURLから類似したLGTM画像を検索
 
 レスポンスモデルはPydanticのBaseModelを使用して定義されており、JSONフィールドにはキャメルケースを使用します（例: `imageUrl`, `imageExtension`）。
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ APIはシンプルなRESTパターンに従い、3つのエンドポイントを
 2. **POST /lgtm-images** - 新しいLGTM画像を作成（base64画像と拡張子を受け取る）
 3. **GET /lgtm-images/recently-created** - 最近作成されたLGTM画像を返す
 4. **POST /lgtm-images/search/text** - テキストからLGTM画像を検索
-5. **POST /lgtm-images/search/image** - 画像から類似したLGTM画像を検索
+5. **POST /lgtm-images/search/image-from-data** - 画像データから類似したLGTM画像を検索
 
 レスポンスモデルはPydanticのBaseModelを使用して定義されており、JSONフィールドにはキャメルケースを使用します（例: `imageUrl`, `imageExtension`）。
 

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -24,6 +24,7 @@ from log.url_sanitizer import sanitize_url_for_logging
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageFromUrlRequest,
     LgtmImageSearchByImageRequest,
 )
 from presentation.controller.lgtm_image_response import (
@@ -50,6 +51,9 @@ from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
 )
 from usecase.search_lgtm_images_by_image import SearchLgtmImagesByImageUsecase
+from usecase.search_lgtm_images_by_image_from_url_usecase import (
+    SearchLgtmImagesByImageFromUrlUsecase,
+)
 from usecase.search_lgtm_images_by_text import SearchLgtmImagesByTextUsecase
 
 if TYPE_CHECKING:
@@ -262,4 +266,66 @@ class LgtmImageController:
         except Exception as e:
             # エラーハンドリング
             logger.error(f"Error searching LGTM images by image: {e}")
+            return create_error_response(e)
+
+    @staticmethod
+    async def search_by_image_from_url(
+        image_fetch_repository: "ImageFetchRepositoryInterface",
+        repository: LgtmImageSearchRepositoryInterface,
+        request: LgtmImageSearchByImageFromUrlRequest,
+    ) -> JSONResponse:
+        sanitized_url = sanitize_url_for_logging(request.image_url)
+        logger.info(
+            "Searching LGTM images by image from URL",
+            extra={"image_url": sanitized_url},
+        )
+
+        try:
+            # ユースケース実行
+            similar_images = await SearchLgtmImagesByImageFromUrlUsecase.execute(
+                image_fetch_repository=image_fetch_repository,
+                search_repository=repository,
+                image_url=request.image_url,
+            )
+
+            # レスポンスモデルに変換
+            image_items = [
+                LgtmImageSearchItem(
+                    id=img["id"],
+                    url=img["url"],  # type: ignore[arg-type]
+                    similarity_score=img["similarity_score"],
+                )
+                for img in similar_images
+            ]
+            response = LgtmImageSearchByImageResponse(lgtm_images=image_items)
+
+            # JSONResponse返却
+            return create_json_response(response)
+
+        except ErrInvalidUrl as e:
+            logger.error(f"Invalid URL provided: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Invalid URL provided"},
+            )
+        except ErrUrlNotAccessible as e:
+            logger.error(f"URL not accessible: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "URL not accessible"},
+            )
+        except ErrImageFetchFailed as e:
+            logger.error(f"Failed to fetch image: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Failed to fetch image from URL"},
+            )
+        except ErrInvalidImageExtension as e:
+            logger.error(f"Invalid image extension: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Invalid image extension or unsupported format"},
+            )
+        except Exception as e:
+            logger.error(f"Error searching LGTM images by image from URL: {e}")
             return create_error_response(e)

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -96,3 +96,30 @@ class LgtmImageSearchByImageRequest(BaseModel):
         if not can_convert_image_extension(v):
             raise ValueError(f"Invalid image extension: {v}")
         return v
+
+
+class LgtmImageSearchByImageFromUrlRequest(BaseModel):
+    image_url: str = Field(
+        ...,
+        alias="imageUrl",
+        description=("画像のURL(httpsのみ許可)。"),
+        examples=[
+            "https://allowed-bucket.r2.cloudflarestorage.com/image.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+        ],
+        min_length=1,
+    )
+
+    @field_validator("image_url")
+    @classmethod
+    def validate_image_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+
+        # httpsのみ許可
+        if parsed.scheme != "https":
+            raise ValueError("image_url must be https URL")
+
+        # ホスト名が存在することを確認
+        if not parsed.netloc:
+            raise ValueError("image_url must have a valid hostname")
+
+        return v

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -16,11 +16,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config import (
     get_aws_bedrock_embedding_model_id,
     get_aws_bedrock_region,
+    get_image_allowed_domain,
+    get_image_fetch_timeout,
     get_lgtm_images_base_url,
+    get_max_image_size,
     get_s3_vector_bucket_name,
     get_s3_vector_index_name,
     get_s3_vector_region,
     get_upload_s3_bucket_name,
+)
+from domain.repository.image_fetch_repository_interface import (
+    ImageFetchRepositoryInterface,
 )
 from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
@@ -35,11 +41,15 @@ from infrastructure.bedrock_client import BedrockClient
 from infrastructure.database import create_db_session
 from infrastructure.lgtm_image_repository import LgtmImageRepository
 from infrastructure.lgtm_image_search_repository import LgtmImageSearchRepository
+from infrastructure.repository.http_image_fetch_repository import (
+    HttpImageFetchRepository,
+)
 from infrastructure.s3_repository import S3Repository
 from infrastructure.s3_vector_client import S3VectorClient
 from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageFromUrlRequest,
     LgtmImageSearchByImageRequest,
     TextSearchRequest,
 )
@@ -79,6 +89,17 @@ def create_lgtm_image_search_repository(
         index_name=s3_vector_index_name,
     )
     return LgtmImageSearchRepository(bedrock_client, s3_vector_client, base_url)
+
+
+def create_image_fetch_repository(
+    timeout: Annotated[int, Depends(get_image_fetch_timeout)],
+    max_size: Annotated[int, Depends(get_max_image_size)],
+    allowed_domain: Annotated[str, Depends(get_image_allowed_domain)],
+) -> ImageFetchRepositoryInterface:
+    """画像取得リポジトリのインスタンスを生成"""
+    return HttpImageFetchRepository(
+        timeout=timeout, max_size=max_size, allowed_domain=allowed_domain
+    )
 
 
 @router.post(
@@ -366,3 +387,102 @@ async def search_by_image(
     token_payload: Annotated[dict[str, Any], Depends(verify_token)],
 ) -> JSONResponse:
     return await LgtmImageController.search_by_image(repository, request_body)
+
+
+@router.post(
+    "/lgtm-images/search/image-from-url",
+    summary="署名付きURLから類似したLGTM画像を検索",
+    description="許可された署名付きURLから画像を取得して類似画像を検索して返します。最大9件まで返却されます。",
+    response_description="類似画像検索結果のリスト（類似度の高い順）",
+    response_model=LgtmImageSearchByImageResponse,
+    tags=["LGTM Images"],
+    responses={
+        200: {
+            "description": "成功時のレスポンス",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "lgtmImages": [
+                            {
+                                "id": "1",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.95,
+                            },
+                            {
+                                "id": "2",
+                                "url": "https://lgtm-images.lgtmeow.com/2021/03/16/23/6947f291-a46e-453c-a230-0d756d7174cb.webp",
+                                "similarityScore": 0.87,
+                            },
+                        ]
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "無効なURLまたは許可されていないドメイン",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "invalid_url": {
+                            "summary": "無効なURL",
+                            "value": {"error": "Invalid URL provided"},
+                        },
+                        "url_not_accessible": {
+                            "summary": "URLにアクセスできない",
+                            "value": {"error": "URL not accessible"},
+                        },
+                    }
+                }
+            },
+        },
+        401: {
+            "description": "認証エラー",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Invalid authorization header"}
+                }
+            },
+        },
+        422: {
+            "description": "画像取得失敗または無効な画像形式",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "fetch_failed": {
+                            "summary": "画像取得失敗",
+                            "value": {"error": "Failed to fetch image from URL"},
+                        },
+                        "invalid_format": {
+                            "summary": "無効な画像形式",
+                            "value": {
+                                "error": "Invalid image extension or unsupported format"
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        500: {
+            "description": "サーバーエラー",
+            "content": {
+                "application/json": {"example": {"error": "Internal server error"}}
+            },
+        },
+    },
+)
+async def search_by_image_from_url(
+    request_body: LgtmImageSearchByImageFromUrlRequest,
+    image_fetch_repository: Annotated[
+        ImageFetchRepositoryInterface, Depends(create_image_fetch_repository)
+    ],
+    repository: Annotated[
+        LgtmImageSearchRepositoryInterface,
+        Depends(create_lgtm_image_search_repository),
+    ],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
+) -> JSONResponse:
+    return await LgtmImageController.search_by_image_from_url(
+        image_fetch_repository,
+        repository,
+        request_body,
+    )

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -296,7 +296,7 @@ async def search_lgtm_images_by_text(
 
 
 @router.post(
-    "/lgtm-images/search/image",
+    "/lgtm-images/search/image-from-data",
     summary="画像から類似したLGTM画像を検索",
     description="ユーザーから入力された画像と類似する画像を検索して返します。最大9件まで返却されます。",
     response_description="類似画像検索結果のリスト（類似度の高い順）",

--- a/src/usecase/search_lgtm_images_by_image_from_url_usecase.py
+++ b/src/usecase/search_lgtm_images_by_image_from_url_usecase.py
@@ -1,0 +1,68 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+import base64
+
+from domain.image_format import mime_type_to_extension
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+)
+from domain.repository.image_fetch_repository_interface import (
+    ImageFetchRepositoryInterface,
+)
+from domain.repository.lgtm_image_search_repository_interface import (
+    LgtmImageSearchRepositoryInterface,
+)
+from log.logger import get_logger
+from log.url_sanitizer import sanitize_url_for_logging
+
+logger = get_logger(__name__)
+
+
+class SearchLgtmImagesByImageFromUrlUsecase:
+    @staticmethod
+    async def execute(
+        image_fetch_repository: ImageFetchRepositoryInterface,
+        search_repository: LgtmImageSearchRepositoryInterface,
+        image_url: str,
+    ) -> list[LgtmImageSearchResult]:
+        safe_url = sanitize_url_for_logging(image_url)
+        logger.info(
+            "Executing SearchLgtmImagesByImageFromUrlUsecase",
+            extra={"image_url": safe_url},
+        )
+
+        # 外部URLから画像を取得（MIMEタイプも含む）
+        fetched_image = await image_fetch_repository.fetch_image(image_url)
+
+        logger.info(
+            f"Successfully fetched image from URL ({len(fetched_image['data'])} bytes, type: {fetched_image['mime_type']})",
+            extra={
+                "image_url": safe_url,
+                "size": len(fetched_image["data"]),
+                "mime_type": fetched_image["mime_type"],
+            },
+        )
+
+        # MIMEタイプから拡張子を取得
+        image_extension = mime_type_to_extension(fetched_image["mime_type"])
+
+        # バイトデータをbase64エンコード
+        image_data = base64.b64encode(fetched_image["data"]).decode("utf-8")
+
+        logger.info(
+            "Encoded image to base64",
+            extra={"image_extension": image_extension},
+        )
+
+        results = await search_repository.search_by_image(
+            image_data=image_data,
+            image_extension=image_extension,
+            max_results=DEFAULT_SEARCH_MAX_RESULTS,
+        )
+
+        logger.info(
+            "SearchLgtmImagesByImageFromUrlUsecase completed successfully",
+            extra={"results_count": len(results)},
+        )
+
+        return results

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -15,6 +15,7 @@ from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
+    LgtmImageSearchByImageFromUrlRequest,
     LgtmImageSearchByImageRequest,
 )
 from tests.fixtures.test_data_helpers import insert_test_lgtm_images
@@ -880,3 +881,227 @@ class TestLgtmImageController:
         assert content["error"] == "Internal server error"
 
         mock_repository.search_by_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_success(self) -> None:
+        """正常系: 署名付きURLから画像を取得して検索に成功する."""
+        # Arrange
+        image_url = "https://example.com/image.png"
+        expected_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": expected_data, "mime_type": "image/png"}
+        )
+
+        mock_search_repo = AsyncMock()
+        mock_search_repo.search_by_image = AsyncMock(
+            return_value=[
+                {
+                    "id": "1",
+                    "url": "https://lgtm-images.lgtmeow.com/image1.webp",
+                    "similarity_score": 0.95,
+                },
+                {
+                    "id": "2",
+                    "url": "https://lgtm-images.lgtmeow.com/image2.webp",
+                    "similarity_score": 0.87,
+                },
+            ]
+        )
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.search_by_image_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            repository=mock_search_repo,
+            request=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+
+        content = json.loads(bytes(result.body))
+        assert "lgtmImages" in content
+        assert len(content["lgtmImages"]) == 2
+        assert content["lgtmImages"][0]["id"] == "1"
+        assert content["lgtmImages"][0]["similarityScore"] == 0.95
+        assert content["lgtmImages"][1]["id"] == "2"
+        assert content["lgtmImages"][1]["similarityScore"] == 0.87
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_invalid_url(self) -> None:
+        """異常系: 無効なURLの場合、400エラーを返す."""
+        # Arrange
+        image_url = "https://localhost/image.png"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrInvalidUrl
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrInvalidUrl("Invalid URL")
+        )
+
+        mock_search_repo = AsyncMock()
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.search_by_image_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            repository=mock_search_repo,
+            request=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Invalid URL provided" in content["error"]
+
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_url_not_accessible(self) -> None:
+        """異常系: URLにアクセスできない場合、400エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/not-found.png"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrUrlNotAccessible
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrUrlNotAccessible("URL not found")
+        )
+
+        mock_search_repo = AsyncMock()
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.search_by_image_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            repository=mock_search_repo,
+            request=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "URL not accessible" in content["error"]
+
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_fetch_failed(self) -> None:
+        """異常系: 画像取得失敗の場合、422エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/broken-image.png"
+
+        mock_image_fetch_repo = AsyncMock()
+        from domain.lgtm_image_errors import ErrImageFetchFailed
+
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            side_effect=ErrImageFetchFailed("Failed to fetch image")
+        )
+
+        mock_search_repo = AsyncMock()
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        result = await LgtmImageController.search_by_image_from_url(
+            image_fetch_repository=mock_image_fetch_repo,
+            repository=mock_search_repo,
+            request=request_body,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Failed to fetch image from URL" in content["error"]
+
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_invalid_extension(self) -> None:
+        """異常系: 無効な画像形式の場合、422エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/document.pdf"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": b"pdf data", "mime_type": "application/pdf"}
+        )
+
+        mock_search_repo = AsyncMock()
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        from domain.lgtm_image_errors import ErrInvalidImageExtension
+
+        with patch(
+            "presentation.controller.lgtm_image_controller.SearchLgtmImagesByImageFromUrlUsecase.execute",
+            side_effect=ErrInvalidImageExtension("Unsupported MIME type"),
+        ):
+            result = await LgtmImageController.search_by_image_from_url(
+                image_fetch_repository=mock_image_fetch_repo,
+                repository=mock_search_repo,
+                request=request_body,
+            )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Invalid image extension or unsupported format" in content["error"]
+
+    @pytest.mark.asyncio
+    async def test_search_by_image_from_url_general_exception(self) -> None:
+        """異常系: 予期しないエラーが発生した場合、500エラーを返す."""
+        # Arrange
+        image_url = "https://example.com/image.png"
+
+        mock_image_fetch_repo = AsyncMock()
+        mock_image_fetch_repo.fetch_image = AsyncMock(
+            return_value={"data": b"image data", "mime_type": "image/png"}
+        )
+
+        mock_search_repo = AsyncMock()
+
+        request_body = LgtmImageSearchByImageFromUrlRequest(imageUrl=image_url)
+
+        # Act
+        with patch(
+            "presentation.controller.lgtm_image_controller.SearchLgtmImagesByImageFromUrlUsecase.execute",
+            side_effect=Exception("Unexpected error"),
+        ):
+            result = await LgtmImageController.search_by_image_from_url(
+                image_fetch_repository=mock_image_fetch_repo,
+                repository=mock_search_repo,
+                request=request_body,
+            )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert content["error"] == "Internal server error"

--- a/tests/usecase/test_search_lgtm_images_by_image_from_url_usecase.py
+++ b/tests/usecase/test_search_lgtm_images_by_image_from_url_usecase.py
@@ -1,0 +1,246 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.lgtm_image_errors import (
+    ErrImageFetchFailed,
+    ErrInvalidImageExtension,
+    ErrInvalidUrl,
+    ErrUrlNotAccessible,
+)
+from domain.lgtm_image_search import (
+    DEFAULT_SEARCH_MAX_RESULTS,
+    LgtmImageSearchResult,
+)
+from usecase.search_lgtm_images_by_image_from_url_usecase import (
+    SearchLgtmImagesByImageFromUrlUsecase,
+)
+
+
+class TestSearchLgtmImagesByImageFromUrlUsecase:
+    """SearchLgtmImagesByImageFromUrlUsecaseの統合テスト.
+
+    署名付きURLから画像を取得し、類似画像検索を実行する。
+    Repository層のモックを使用してテストを実施する。
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_valid_url(self) -> None:
+        """正常系: 署名付きURLから画像を取得して検索成功."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        # 画像取得のモック
+        mock_image_fetch_repo.fetch_image.return_value = {
+            "data": b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR...",
+            "mime_type": "image/png",
+        }
+
+        # 検索結果のモック
+        mock_results: list[LgtmImageSearchResult] = [
+            {
+                "id": "1",
+                "url": "https://example.com/image1.webp",
+                "similarity_score": 0.95,
+            },
+            {
+                "id": "2",
+                "url": "https://example.com/image2.webp",
+                "similarity_score": 0.87,
+            },
+        ]
+        mock_search_repo.search_by_image.return_value = mock_results
+
+        image_url = "https://allowed-bucket.r2.cloudflarestorage.com/image.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+
+        # Act
+        result = await SearchLgtmImagesByImageFromUrlUsecase.execute(
+            image_fetch_repository=mock_image_fetch_repo,
+            search_repository=mock_search_repo,
+            image_url=image_url,
+        )
+
+        # Assert
+        assert len(result) == 2
+        assert result == mock_results
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_called_once()
+        # base64エンコードされた画像データが渡されることを確認
+        call_args = mock_search_repo.search_by_image.call_args
+        assert call_args.kwargs["image_extension"] == ".png"
+        assert call_args.kwargs["max_results"] == DEFAULT_SEARCH_MAX_RESULTS
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_url(self) -> None:
+        """異常系: 無効なURLの場合、ErrInvalidUrlが発生する."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        mock_image_fetch_repo.fetch_image.side_effect = ErrInvalidUrl(
+            "Invalid URL format"
+        )
+
+        image_url = "invalid-url"
+
+        # Act & Assert
+        with pytest.raises(ErrInvalidUrl):
+            await SearchLgtmImagesByImageFromUrlUsecase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                search_repository=mock_search_repo,
+                image_url=image_url,
+            )
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_url_not_accessible(self) -> None:
+        """異常系: URLにアクセスできない場合、ErrUrlNotAccessibleが発生する."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        mock_image_fetch_repo.fetch_image.side_effect = ErrUrlNotAccessible(
+            "URL is not accessible"
+        )
+
+        image_url = "https://disallowed-domain.com/image.jpg"
+
+        # Act & Assert
+        with pytest.raises(ErrUrlNotAccessible):
+            await SearchLgtmImagesByImageFromUrlUsecase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                search_repository=mock_search_repo,
+                image_url=image_url,
+            )
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_image_fetch_failed(self) -> None:
+        """異常系: 画像取得失敗の場合、ErrImageFetchFailedが発生する."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        mock_image_fetch_repo.fetch_image.side_effect = ErrImageFetchFailed(
+            "Failed to fetch image"
+        )
+
+        image_url = "https://example.com/broken-image.jpg"
+
+        # Act & Assert
+        with pytest.raises(ErrImageFetchFailed):
+            await SearchLgtmImagesByImageFromUrlUsecase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                search_repository=mock_search_repo,
+                image_url=image_url,
+            )
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_image_extension(self) -> None:
+        """異常系: 無効な画像形式の場合、ErrInvalidImageExtensionが発生する."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        # 無効なMIMEタイプを返す
+        mock_image_fetch_repo.fetch_image.return_value = {
+            "data": b"invalid data",
+            "mime_type": "application/pdf",  # PDFは許可されていない
+        }
+
+        image_url = "https://example.com/document.pdf"
+
+        # Act & Assert
+        with pytest.raises(ErrInvalidImageExtension):
+            await SearchLgtmImagesByImageFromUrlUsecase.execute(
+                image_fetch_repository=mock_image_fetch_repo,
+                search_repository=mock_search_repo,
+                image_url=image_url,
+            )
+
+        mock_image_fetch_repo.fetch_image.assert_called_once_with(image_url)
+        mock_search_repo.search_by_image.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("mime_type", "expected_extension"),
+        [
+            ("image/jpeg", ".jpg"),
+            ("image/png", ".png"),
+        ],
+        ids=["jpeg", "png"],
+    )
+    async def test_execute_success_with_various_mime_types(
+        self, mime_type: str, expected_extension: str
+    ) -> None:
+        """正常系: 各種MIMEタイプで正常に動作する."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        mock_image_fetch_repo.fetch_image.return_value = {
+            "data": b"image data",
+            "mime_type": mime_type,
+        }
+
+        mock_results: list[LgtmImageSearchResult] = [
+            {
+                "id": "1",
+                "url": "https://example.com/image1.webp",
+                "similarity_score": 0.90,
+            }
+        ]
+        mock_search_repo.search_by_image.return_value = mock_results
+
+        image_url = "https://example.com/image.jpg"
+
+        # Act
+        result = await SearchLgtmImagesByImageFromUrlUsecase.execute(
+            image_fetch_repository=mock_image_fetch_repo,
+            search_repository=mock_search_repo,
+            image_url=image_url,
+        )
+
+        # Assert
+        assert len(result) == 1
+        assert result == mock_results
+        call_args = mock_search_repo.search_by_image.call_args
+        assert call_args.kwargs["image_extension"] == expected_extension
+        assert call_args.kwargs["max_results"] == DEFAULT_SEARCH_MAX_RESULTS
+
+    @pytest.mark.asyncio
+    async def test_execute_success_with_empty_results(self) -> None:
+        """正常系: 検索結果が0件の場合でも空のリストが返る."""
+        # Arrange
+        mock_image_fetch_repo = AsyncMock()
+        mock_search_repo = AsyncMock()
+
+        mock_image_fetch_repo.fetch_image.return_value = {
+            "data": b"image data",
+            "mime_type": "image/jpeg",
+        }
+        mock_search_repo.search_by_image.return_value = []
+
+        image_url = "https://example.com/image.jpg"
+
+        # Act
+        result = await SearchLgtmImagesByImageFromUrlUsecase.execute(
+            image_fetch_repository=mock_image_fetch_repo,
+            search_repository=mock_search_repo,
+            image_url=image_url,
+        )
+
+        # Assert
+        assert len(result) == 0
+        assert result == []
+        mock_search_repo.search_by_image.assert_called_once()


### PR DESCRIPTION
# issueURL

#70

# この PR で対応する範囲 / この PR で対応しない範囲

## この PR で対応する範囲
- 署名付きURLから画像を取得して類似画像検索を行う新しいエンドポイント `POST /lgtm-images/search/image-from-url` の追加
- 既存エンドポイント `/lgtm-images/search/image` を `/lgtm-images/search/image-from-data` にパス変更

## この PR で対応しない範囲
- 特になし

# 変更点概要

外部の署名付きURLから画像を取得して類似画像検索を実行する機能を追加した。クライアントがアップロードした画像のURLを指定することで、サーバー側で画像を取得し、ベクトル検索で類似した画像を返す仕組みである。

エンドポイントのパス整理も実施し、既存の `/lgtm-images/search/image` を `/lgtm-images/search/image-from-data` に変更することで、画像データから直接検索する場合と、URLから検索する場合を明確に区別した。