### PR TITLE
猫画像判定APIエンドポイントの追加（Presentation層）

### DIFF
--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -388,9 +388,7 @@ class LgtmImageController:
             )
         except ErrRekognitionFailed as e:
             logger.error(f"Rekognition API error: {e}")
-            return JSONResponse(
-                status_code=500, content={"error": "Image validation failed"}
-            )
+            return create_error_response(e)
         except Exception as e:
             logger.error(f"Unexpected error in validate_cat_image: {e}")
-            return JSONResponse(status_code=500, content={"error": str(e)})
+            return create_error_response(e)

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -14,6 +14,7 @@ from domain.lgtm_image_errors import (
     ErrInvalidSearchQuery,
     ErrInvalidUrl,
     ErrRecordCount,
+    ErrRekognitionFailed,
     ErrUrlNotAccessible,
 )
 from domain.repository.lgtm_image_repository_interface import (
@@ -22,12 +23,14 @@ from domain.repository.lgtm_image_repository_interface import (
 from log.logger import get_logger
 from log.url_sanitizer import sanitize_url_for_logging
 from presentation.controller.lgtm_image_request import (
+    CatImageValidationRequest,
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
     LgtmImageSearchByImageFromUrlRequest,
     LgtmImageSearchByImageRequest,
 )
 from presentation.controller.lgtm_image_response import (
+    CatImageValidationResponse,
     LgtmImageCreateResponse,
     LgtmImageItem,
     LgtmImageRandomListResponse,
@@ -55,8 +58,11 @@ from usecase.search_lgtm_images_by_image_from_url_usecase import (
     SearchLgtmImagesByImageFromUrlUsecase,
 )
 from usecase.search_lgtm_images_by_text import SearchLgtmImagesByTextUsecase
+from usecase.validate_cat_image_usecase import ValidateCatImageUseCase
 
 if TYPE_CHECKING:
+    from domain.cat_image_validation_policy import CatImageValidationPolicy
+    from domain.image_analysis_interface import ImageAnalysisServiceInterface
     from domain.repository.image_fetch_repository_interface import (
         ImageFetchRepositoryInterface,
     )
@@ -329,3 +335,62 @@ class LgtmImageController:
         except Exception as e:
             logger.error(f"Error searching LGTM images by image from URL: {e}")
             return create_error_response(e)
+
+    @staticmethod
+    async def validate_cat_image(
+        request: CatImageValidationRequest,
+        image_analysis_service: "ImageAnalysisServiceInterface",
+        image_fetch_repository: "ImageFetchRepositoryInterface",
+        policy: "CatImageValidationPolicy",
+    ) -> JSONResponse:
+        sanitized_url = sanitize_url_for_logging(request.image_url)
+        logger.info(
+            "Validating cat image",
+            extra={"image_url": sanitized_url},
+        )
+
+        try:
+            usecase = ValidateCatImageUseCase(
+                image_analysis_service, image_fetch_repository, policy
+            )
+            result = await usecase.execute(request.image_url)
+
+            response = CatImageValidationResponse(
+                isAcceptableCatImage=result["is_acceptable"],
+                notAcceptableReason=result.get("reason"),
+            )
+
+            return create_json_response(response)
+
+        except ErrInvalidUrl as e:
+            logger.error(f"Invalid URL provided: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Invalid URL provided"},
+            )
+        except ErrUrlNotAccessible as e:
+            logger.error(f"URL not accessible: {e}")
+            return JSONResponse(
+                status_code=400,
+                content={"error": "URL not accessible"},
+            )
+        except ErrImageFetchFailed as e:
+            logger.error(f"Failed to fetch image: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Failed to fetch image from URL"},
+            )
+        except ErrInvalidImageExtension as e:
+            logger.error(f"Invalid image extension: {e}")
+            return JSONResponse(
+                status_code=422,
+                content={"error": "Invalid image extension or unsupported format"},
+            )
+        except ErrRekognitionFailed as e:
+            logger.error(f"Rekognition API error: {e}")
+            return JSONResponse(
+                status_code=500, content={"error": "Image validation failed"}
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error in validate_cat_image: {e}")
+            return JSONResponse(status_code=500, content={"error": str(e)})

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -356,8 +356,8 @@ class LgtmImageController:
             result = await usecase.execute(request.image_url)
 
             response = CatImageValidationResponse(
-                isAcceptableCatImage=result["is_acceptable"],
-                notAcceptableReason=result.get("reason"),
+                is_acceptable_cat_image=result["is_acceptable"],
+                not_acceptable_reason=result.get("reason"),
             )
 
             return create_json_response(response)

--- a/src/presentation/controller/lgtm_image_request.py
+++ b/src/presentation/controller/lgtm_image_request.py
@@ -123,3 +123,30 @@ class LgtmImageSearchByImageFromUrlRequest(BaseModel):
             raise ValueError("image_url must have a valid hostname")
 
         return v
+
+
+class CatImageValidationRequest(BaseModel):
+    image_url: str = Field(
+        ...,
+        alias="imageUrl",
+        description=("画像のURL(httpsのみ許可)。"),
+        examples=[
+            "https://allowed-bucket.r2.cloudflarestorage.com/image.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+        ],
+        min_length=1,
+    )
+
+    @field_validator("image_url")
+    @classmethod
+    def validate_image_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+
+        # httpsのみ許可
+        if parsed.scheme != "https":
+            raise ValueError("image_url must be https URL")
+
+        # ホスト名が存在することを確認
+        if not parsed.netloc:
+            raise ValueError("image_url must have a valid hostname")
+
+        return v

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -129,13 +129,13 @@ class LgtmImageSearchByImageResponse(BaseModel):
 class CatImageValidationResponse(BaseModel):
     is_acceptable_cat_image: bool = Field(
         ...,
-        alias="isAcceptableCatImage",
+        serialization_alias="isAcceptableCatImage",
         description="受け入れ可能な猫画像かどうか",
         examples=[True, False],
     )
     not_acceptable_reason: str | None = Field(
         None,
-        alias="notAcceptableReason",
+        serialization_alias="notAcceptableReason",
         description="受け入れ不可の理由",
         examples=[
             "not cat image",

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -124,3 +124,22 @@ class LgtmImageSearchByImageResponse(BaseModel):
             ]
         ],
     )
+
+
+class CatImageValidationResponse(BaseModel):
+    is_acceptable_cat_image: bool = Field(
+        ...,
+        alias="isAcceptableCatImage",
+        description="受け入れ可能な猫画像かどうか",
+        examples=[True, False],
+    )
+    not_acceptable_reason: str | None = Field(
+        None,
+        alias="notAcceptableReason",
+        description="受け入れ不可の理由",
+        examples=[
+            "not cat image",
+            "person face in the image",
+            "not moderation image",
+        ],
+    )

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -43,6 +43,7 @@ from domain.cat_image_validation_policy import (
     CatImageValidationPolicy,
     DEFAULT_VALIDATION_POLICY,
 )
+from domain.image_analysis_interface import ImageAnalysisServiceInterface
 from infrastructure.bedrock_client import BedrockClient
 from infrastructure.database import create_db_session
 from infrastructure.lgtm_image_repository import LgtmImageRepository
@@ -114,8 +115,8 @@ def create_image_fetch_repository(
 
 def create_image_analysis_service(
     region: Annotated[str, Depends(get_aws_rekognition_region)],
-) -> RekognitionImageAnalysisService:
-    """RekognitionImageAnalysisServiceインスタンスを生成"""
+) -> ImageAnalysisServiceInterface:
+    """ImageAnalysisServiceInterfaceインスタンスを生成"""
     return RekognitionImageAnalysisService(region=region)
 
 
@@ -585,7 +586,7 @@ async def search_by_image_from_url(
 async def validate_cat_image(
     request_body: CatImageValidationRequest,
     image_analysis_service: Annotated[
-        RekognitionImageAnalysisService, Depends(create_image_analysis_service)
+        ImageAnalysisServiceInterface, Depends(create_image_analysis_service)
     ],
     image_fetch_repository: Annotated[
         ImageFetchRepositoryInterface, Depends(create_image_fetch_repository)

--- a/src/presentation/router/lgtm_image_router.py
+++ b/src/presentation/router/lgtm_image_router.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from presentation.controller.lgtm_image_response import (
+    CatImageValidationResponse,
     LgtmImageCreateResponse,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
@@ -16,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config import (
     get_aws_bedrock_embedding_model_id,
     get_aws_bedrock_region,
+    get_aws_rekognition_region,
     get_image_allowed_domain,
     get_image_fetch_timeout,
     get_lgtm_images_base_url,
@@ -37,10 +39,17 @@ from domain.repository.lgtm_image_search_repository_interface import (
 from domain.repository.object_storage_repository_interface import (
     ObjectStorageRepositoryInterface,
 )
+from domain.cat_image_validation_policy import (
+    CatImageValidationPolicy,
+    DEFAULT_VALIDATION_POLICY,
+)
 from infrastructure.bedrock_client import BedrockClient
 from infrastructure.database import create_db_session
 from infrastructure.lgtm_image_repository import LgtmImageRepository
 from infrastructure.lgtm_image_search_repository import LgtmImageSearchRepository
+from infrastructure.rekognition_image_analysis_service import (
+    RekognitionImageAnalysisService,
+)
 from infrastructure.repository.http_image_fetch_repository import (
     HttpImageFetchRepository,
 )
@@ -48,6 +57,7 @@ from infrastructure.s3_repository import S3Repository
 from infrastructure.s3_vector_client import S3VectorClient
 from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
+    CatImageValidationRequest,
     LgtmImageCreateRequest,
     LgtmImageSearchByImageFromUrlRequest,
     LgtmImageSearchByImageRequest,
@@ -100,6 +110,18 @@ def create_image_fetch_repository(
     return HttpImageFetchRepository(
         timeout=timeout, max_size=max_size, allowed_domain=allowed_domain
     )
+
+
+def create_image_analysis_service(
+    region: Annotated[str, Depends(get_aws_rekognition_region)],
+) -> RekognitionImageAnalysisService:
+    """RekognitionImageAnalysisServiceインスタンスを生成"""
+    return RekognitionImageAnalysisService(region=region)
+
+
+def get_validation_policy() -> CatImageValidationPolicy:
+    """猫画像判定ポリシーを取得"""
+    return DEFAULT_VALIDATION_POLICY
 
 
 @router.post(
@@ -485,4 +507,95 @@ async def search_by_image_from_url(
         image_fetch_repository,
         repository,
         request_body,
+    )
+
+
+@router.post(
+    "/lgtm-images/validate-cat",
+    summary="猫画像判定",
+    description="署名付きURLから画像を取得し、LGTM画像として適切な猫画像かを判定します。不適切なコンテンツ、人の顔、猫以外の画像を検出します。",
+    response_description="猫画像判定結果",
+    response_model=CatImageValidationResponse,
+    tags=["LGTM Images"],
+    responses={
+        200: {
+            "description": "判定成功",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "acceptable": {
+                            "summary": "受け入れ可能な猫画像",
+                            "value": {"isAcceptableCatImage": True},
+                        },
+                        "not_acceptable": {
+                            "summary": "受け入れ不可の画像",
+                            "value": {
+                                "isAcceptableCatImage": False,
+                                "notAcceptableReason": "not cat image",
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "無効なURL、またはアクセスできないURL",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "invalid_url": {
+                            "summary": "無効なURL",
+                            "value": {"error": "Invalid URL provided"},
+                        },
+                        "url_not_accessible": {
+                            "summary": "アクセスできないURL",
+                            "value": {"error": "URL not accessible"},
+                        },
+                    }
+                }
+            },
+        },
+        422: {
+            "description": "画像取得失敗、または無効な画像形式",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "fetch_failed": {
+                            "summary": "画像取得失敗",
+                            "value": {"error": "Failed to fetch image from URL"},
+                        },
+                        "invalid_extension": {
+                            "summary": "無効な画像形式",
+                            "value": {
+                                "error": "Invalid image extension or unsupported format"
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        500: {
+            "description": "サーバーエラー（画像解析失敗、予期しないエラー）",
+            "content": {
+                "application/json": {"example": {"error": "Image validation failed"}}
+            },
+        },
+    },
+)
+async def validate_cat_image(
+    request_body: CatImageValidationRequest,
+    image_analysis_service: Annotated[
+        RekognitionImageAnalysisService, Depends(create_image_analysis_service)
+    ],
+    image_fetch_repository: Annotated[
+        ImageFetchRepositoryInterface, Depends(create_image_fetch_repository)
+    ],
+    policy: Annotated[CatImageValidationPolicy, Depends(get_validation_policy)],
+    token_payload: Annotated[dict[str, Any], Depends(verify_token)],
+) -> JSONResponse:
+    return await LgtmImageController.validate_cat_image(
+        request_body,
+        image_analysis_service,
+        image_fetch_repository,
+        policy,
     )

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -1313,7 +1313,7 @@ class TestLgtmImageController:
         # Assert
         assert response.status_code == 500
         response_data = json.loads(bytes(response.body))
-        assert response_data["error"] == "Image validation failed"
+        assert response_data["error"] == "Internal server error"
 
     @pytest.mark.asyncio
     @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
@@ -1341,4 +1341,4 @@ class TestLgtmImageController:
         # Assert
         assert response.status_code == 500
         response_data = json.loads(bytes(response.body))
-        assert response_data["error"] == "Unexpected error"
+        assert response_data["error"] == "Internal server error"

--- a/tests/presentation/controller/test_lgtm_image_controller.py
+++ b/tests/presentation/controller/test_lgtm_image_controller.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -10,9 +11,11 @@ from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from domain.cat_image_validation_policy import CatImageValidationPolicy
 from infrastructure.lgtm_image_repository import LgtmImageRepository
 from presentation.controller.lgtm_image_controller import LgtmImageController
 from presentation.controller.lgtm_image_request import (
+    CatImageValidationRequest,
     LgtmImageCreateFromUrlRequest,
     LgtmImageCreateRequest,
     LgtmImageSearchByImageFromUrlRequest,
@@ -1105,3 +1108,237 @@ class TestLgtmImageController:
         content = json.loads(bytes(result.body))
         assert "error" in content
         assert content["error"] == "Internal server error"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_success_acceptable(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """正常系: UseCaseがis_acceptable=Trueを返した場合、200を返す."""
+        # Arrange
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(return_value={"is_acceptable": True})
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 200
+        response_data = json.loads(bytes(response.body))
+        assert response_data["isAcceptableCatImage"] is True
+        assert "notAcceptableReason" not in response_data
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_success_not_acceptable(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """正常系: UseCaseがis_acceptable=Falseを返した場合、200とreasonを返す."""
+        # Arrange
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            return_value={"is_acceptable": False, "reason": "test reason"}
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 200
+        response_data = json.loads(bytes(response.body))
+        assert response_data["isAcceptableCatImage"] is False
+        assert response_data["notAcceptableReason"] == "test reason"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_invalid_url_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: ErrInvalidUrlが発生した場合、400を返す."""
+        # Arrange
+        from domain.lgtm_image_errors import ErrInvalidUrl
+
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=ErrInvalidUrl("Invalid URL")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 400
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "Invalid URL provided"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_url_not_accessible_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: ErrUrlNotAccessibleが発生した場合、400を返す."""
+        # Arrange
+        from domain.lgtm_image_errors import ErrUrlNotAccessible
+
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=ErrUrlNotAccessible("URL not accessible")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 400
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "URL not accessible"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_fetch_failed_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: ErrImageFetchFailedが発生した場合、422を返す."""
+        # Arrange
+        from domain.lgtm_image_errors import ErrImageFetchFailed
+
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=ErrImageFetchFailed("Fetch failed")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 422
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "Failed to fetch image from URL"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_invalid_extension_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: ErrInvalidImageExtensionが発生した場合、422を返す."""
+        # Arrange
+        from domain.lgtm_image_errors import ErrInvalidImageExtension
+
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=ErrInvalidImageExtension("Invalid extension")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 422
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "Invalid image extension or unsupported format"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_rekognition_failed_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: ErrRekognitionFailedが発生した場合、500を返す."""
+        # Arrange
+        from domain.lgtm_image_errors import ErrRekognitionFailed
+
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=ErrRekognitionFailed("Rekognition API error")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 500
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "Image validation failed"
+
+    @pytest.mark.asyncio
+    @patch("presentation.controller.lgtm_image_controller.ValidateCatImageUseCase")
+    async def test_validate_cat_image_unexpected_error(
+        self, mock_usecase_class: Mock
+    ) -> None:
+        """例外系: 予期しない例外が発生した場合、500を返す."""
+        # Arrange
+        mock_usecase_instance = AsyncMock()
+        mock_usecase_instance.execute = AsyncMock(
+            side_effect=Exception("Unexpected error")
+        )
+        mock_usecase_class.return_value = mock_usecase_instance
+
+        request = CatImageValidationRequest(imageUrl="https://example.com/cat.jpg")
+        mock_service = AsyncMock()
+        mock_repo = AsyncMock()
+        mock_policy = cast(CatImageValidationPolicy, {})
+
+        # Act
+        response = await LgtmImageController.validate_cat_image(
+            request, mock_service, mock_repo, mock_policy
+        )
+
+        # Assert
+        assert response.status_code == 500
+        response_data = json.loads(bytes(response.body))
+        assert response_data["error"] == "Unexpected error"


### PR DESCRIPTION
# Issue URL

https://github.com/nekochans/lgtm-cat-api/issues/74

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- 猫画像判定ユースケースを外部から呼び出すための `POST /lgtm-images/validate-cat` エンドポイントの実装
- Controller層でのリクエスト/レスポンス処理とエラーハンドリング
- Router層での依存性注入（DI）設定とOpenAPIドキュメント定義

**対応しない範囲:**
- ユースケース層・インフラ層の実装（別PRで対応済み）
- 既存コントローラーテストの方針統一・ファイル分割（#76 で対応予定）

# 変更点概要

猫画像判定ユースケース（UseCase層・インフラ層で既に実装済み）を外部から呼び出せるようにするため、Presentation層に `POST /lgtm-images/validate-cat` エンドポイントを新設した。

主な実装内容:
- `CatImageValidationRequest`: 署名付きURL（https）を受け取るリクエストモデル
- `CatImageValidationResponse`: 判定結果（受け入れ可否と理由）を返すレスポンスモデル
- `LgtmImageController.validate_cat_image`: ユースケース呼び出しと各種エラーハンドリング
- Router: 依存性注入（ImageAnalysisService、ImageFetchRepository、ValidationPolicy）とOpenAPIドキュメント定義

# レビュアーに重点的にチェックして欲しい点

**コントローラーテストの方針について**

今回の `validate_cat_image` テストは「UseCaseをモック」する方針で実装している。この方針の特徴:
- Controller層の責務（リクエスト処理、エラーハンドリング、レスポンス変換）のみをテスト
- UseCase層以下は別途テスト済みのため、モックで代替
- 実DBや外部サービスへの依存がなく、高速かつ安定したテストが可能

既存のコントローラーテストは「実DB使用」「内部関数patch」など方針が混在しているため、#76 で本方針への統一とファイル分割を行う予定である。

# 補足情報

エラーハンドリングは以下のHTTPステータスコードにマッピングしている:
- 400: 無効なURL、アクセスできないURL
- 422: 画像取得失敗、無効な画像形式
- 500: 画像解析失敗、その他予期しないエラー

**関連Issue:**
- #76 コントローラー層テストの責務統一とファイル分割