### PR TITLE
S3オブジェクト参照による猫画像判定機能の基盤実装

### DIFF
--- a/src/domain/image_analysis_interface.py
+++ b/src/domain/image_analysis_interface.py
@@ -27,3 +27,15 @@ class ImageAnalysisServiceInterface(Protocol):
     async def detect_labels(
         self, image_bytes: bytes, max_labels: int, min_confidence: float
     ) -> list[LabelDetection]: ...
+
+    async def detect_moderation_labels_from_s3(
+        self, bucket: str, key: str, min_confidence: float
+    ) -> list[ModerationLabelDetection]: ...
+
+    async def detect_faces_from_s3(
+        self, bucket: str, key: str
+    ) -> list[FaceDetection]: ...
+
+    async def detect_labels_from_s3(
+        self, bucket: str, key: str, max_labels: int, min_confidence: float
+    ) -> list[LabelDetection]: ...

--- a/src/infrastructure/rekognition_image_analysis_service.py
+++ b/src/infrastructure/rekognition_image_analysis_service.py
@@ -79,3 +79,72 @@ class RekognitionImageAnalysisService(ImageAnalysisServiceInterface):
             raise ErrRekognitionFailed(f"DetectLabels failed: {e}") from e
         except Exception as e:
             raise ErrRekognitionFailed(f"Unexpected error in DetectLabels: {e}") from e
+
+    async def detect_moderation_labels_from_s3(
+        self, bucket: str, key: str, min_confidence: float
+    ) -> list[ModerationLabelDetection]:
+        try:
+            async with self.session.client(
+                "rekognition", region_name=self.region
+            ) as client:
+                response = await client.detect_moderation_labels(
+                    Image={"S3Object": {"Bucket": bucket, "Name": key}},
+                    MinConfidence=min_confidence,
+                )
+                return [
+                    ModerationLabelDetection(
+                        name=label["Name"],
+                        confidence=label["Confidence"],
+                    )
+                    for label in response.get("ModerationLabels", [])
+                ]
+        except (BotoCoreError, ClientError) as e:
+            raise ErrRekognitionFailed(
+                f"DetectModerationLabels from S3 failed: {e}"
+            ) from e
+        except Exception as e:
+            raise ErrRekognitionFailed(
+                f"Unexpected error in DetectModerationLabels from S3: {e}"
+            ) from e
+
+    async def detect_faces_from_s3(self, bucket: str, key: str) -> list[FaceDetection]:
+        try:
+            async with self.session.client(
+                "rekognition", region_name=self.region
+            ) as client:
+                response = await client.detect_faces(
+                    Image={"S3Object": {"Bucket": bucket, "Name": key}}
+                )
+                return [
+                    FaceDetection(confidence=face["Confidence"])
+                    for face in response.get("FaceDetails", [])
+                ]
+        except (BotoCoreError, ClientError) as e:
+            raise ErrRekognitionFailed(f"DetectFaces from S3 failed: {e}") from e
+        except Exception as e:
+            raise ErrRekognitionFailed(
+                f"Unexpected error in DetectFaces from S3: {e}"
+            ) from e
+
+    async def detect_labels_from_s3(
+        self, bucket: str, key: str, max_labels: int, min_confidence: float
+    ) -> list[LabelDetection]:
+        try:
+            async with self.session.client(
+                "rekognition", region_name=self.region
+            ) as client:
+                response = await client.detect_labels(
+                    Image={"S3Object": {"Bucket": bucket, "Name": key}},
+                    MaxLabels=max_labels,
+                    MinConfidence=min_confidence,
+                )
+                return [
+                    LabelDetection(name=label["Name"], confidence=label["Confidence"])
+                    for label in response.get("Labels", [])
+                ]
+        except (BotoCoreError, ClientError) as e:
+            raise ErrRekognitionFailed(f"DetectLabels from S3 failed: {e}") from e
+        except Exception as e:
+            raise ErrRekognitionFailed(
+                f"Unexpected error in DetectLabels from S3: {e}"
+            ) from e

--- a/src/usecase/validate_cat_image_from_s3_usecase.py
+++ b/src/usecase/validate_cat_image_from_s3_usecase.py
@@ -1,0 +1,95 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+"""S3オブジェクトを参照した猫画像判定ユースケース"""
+
+from domain.cat_image_validation_policy import (
+    DEFAULT_VALIDATION_POLICY,
+    CatImageValidationPolicy,
+    CatImageValidationResult,
+)
+from domain.image_analysis_interface import ImageAnalysisServiceInterface
+from domain.lgtm_image_errors import (
+    ErrNotCatImage,
+    ErrNotModerationImage,
+    ErrPersonFaceInImage,
+)
+
+
+class ValidateCatImageFromS3UseCase:
+    def __init__(
+        self,
+        image_analysis_service: ImageAnalysisServiceInterface,
+        policy: CatImageValidationPolicy = DEFAULT_VALIDATION_POLICY,
+    ) -> None:
+        self.image_analysis_service = image_analysis_service
+        self.policy = policy
+
+    async def execute(self, bucket: str, key: str) -> CatImageValidationResult:
+        """
+        S3オブジェクトを参照して猫画像のバリデーションを実行する。
+
+        Args:
+            bucket: S3バケット名
+            key: S3オブジェクトキー
+
+        Returns:
+            CatImageValidationResult: バリデーション結果
+
+        Raises:
+            ErrRekognitionFailed: Rekognitionサービスの障害時に発生。
+                S3オブジェクトが存在しない場合やアクセス権限がない場合も含む。
+                インフラ層の障害を示すため意図的にキャッチせず伝播させ、
+                Controller層で500エラーに変換される。
+
+        Note:
+            バリデーション判定結果（猫未検出、不適切コンテンツ、人の顔検出）は
+            例外をキャッチしてis_acceptable=Falseのレスポンスに変換する。
+        """
+        try:
+            await self._validate_moderation(bucket, key)
+
+            await self._validate_no_person_face(bucket, key)
+
+            await self._validate_cat_presence(bucket, key)
+
+            return CatImageValidationResult(is_acceptable=True)
+
+        except ErrNotModerationImage:
+            return CatImageValidationResult(
+                is_acceptable=False, reason="not moderation image"
+            )
+        except ErrPersonFaceInImage:
+            return CatImageValidationResult(
+                is_acceptable=False, reason="person face in the image"
+            )
+        except ErrNotCatImage:
+            return CatImageValidationResult(is_acceptable=False, reason="not cat image")
+
+    async def _validate_moderation(self, bucket: str, key: str) -> None:
+        labels = await self.image_analysis_service.detect_moderation_labels_from_s3(
+            bucket, key, self.policy["moderation_min_confidence"]
+        )
+        if labels:
+            raise ErrNotModerationImage("Inappropriate content detected")
+
+    async def _validate_no_person_face(self, bucket: str, key: str) -> None:
+        faces = await self.image_analysis_service.detect_faces_from_s3(bucket, key)
+        min_confidence: float = self.policy["face_detection_min_confidence"]
+        for face in faces:
+            confidence = face["confidence"]
+            if confidence > min_confidence:
+                raise ErrPersonFaceInImage(
+                    f"Person face detected with confidence {confidence}"
+                )
+
+    async def _validate_cat_presence(self, bucket: str, key: str) -> None:
+        labels = await self.image_analysis_service.detect_labels_from_s3(
+            bucket,
+            key,
+            self.policy["labels_max_count"],
+            self.policy["labels_min_confidence"],
+        )
+        min_confidence: float = self.policy["cat_label_min_confidence"]
+        for label in labels:
+            if label["name"] == "Cat" and label["confidence"] > min_confidence:
+                return
+        raise ErrNotCatImage("Cat not detected in image")

--- a/tests/infrastructure/test_rekognition_image_analysis_service.py
+++ b/tests/infrastructure/test_rekognition_image_analysis_service.py
@@ -286,3 +286,289 @@ async def test_detect_labels_unexpected_exception() -> None:
             await service.detect_labels(b"fake_image_data", 10, 75.0)
 
         assert "Unexpected error in DetectLabels" in str(exc_info.value)
+
+
+# S3参照版のテスト
+
+
+@pytest.mark.asyncio
+async def test_detect_moderation_labels_from_s3_success() -> None:
+    """DetectModerationLabels（S3参照版）成功時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_moderation_labels = AsyncMock(
+            return_value={"ModerationLabels": []}
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_moderation_labels_from_s3(
+            "test-bucket", "test-key.jpg", 40.0
+        )
+
+        assert result == []
+        mock_rekognition.detect_moderation_labels.assert_called_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}},
+            MinConfidence=40.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_moderation_labels_from_s3_with_labels() -> None:
+    """DetectModerationLabels（S3参照版）: ラベルが検出された場合のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    aws_response_labels = [
+        {"Name": "Violence", "Confidence": 85.5},
+        {"Name": "Suggestive", "Confidence": 60.2},
+    ]
+
+    expected_labels = [
+        ModerationLabelDetection(name="Violence", confidence=85.5),
+        ModerationLabelDetection(name="Suggestive", confidence=60.2),
+    ]
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_moderation_labels = AsyncMock(
+            return_value={"ModerationLabels": aws_response_labels}
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_moderation_labels_from_s3(
+            "test-bucket", "test-key.jpg", 50.0
+        )
+
+        assert result == expected_labels
+        mock_rekognition.detect_moderation_labels.assert_called_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}},
+            MinConfidence=50.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_moderation_labels_from_s3_failure() -> None:
+    """DetectModerationLabels（S3参照版）失敗時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        error_response = {
+            "Error": {"Code": "InvalidParameterException", "Message": "API Error"}
+        }
+        mock_rekognition.detect_moderation_labels = AsyncMock(
+            side_effect=ClientError(error_response, "DetectModerationLabels")  # type: ignore[arg-type]
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_moderation_labels_from_s3(
+                "test-bucket", "test-key.jpg", 40.0
+            )
+
+        assert "DetectModerationLabels from S3 failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_detect_moderation_labels_from_s3_unexpected_exception() -> None:
+    """DetectModerationLabels（S3参照版）予期しない例外のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_moderation_labels = AsyncMock(
+            side_effect=RuntimeError("Unexpected runtime error")
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_moderation_labels_from_s3(
+                "test-bucket", "test-key.jpg", 40.0
+            )
+
+        assert "Unexpected error in DetectModerationLabels from S3" in str(
+            exc_info.value
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_faces_from_s3_success() -> None:
+    """DetectFaces（S3参照版）成功時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_faces = AsyncMock(return_value={"FaceDetails": []})
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_faces_from_s3("test-bucket", "test-key.jpg")
+
+        assert result == []
+        mock_rekognition.detect_faces.assert_called_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_faces_from_s3_with_faces() -> None:
+    """DetectFaces（S3参照版）: 顔が検出された場合のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    aws_faces = [
+        {"Confidence": 99.5, "BoundingBox": {}},
+        {"Confidence": 98.2, "BoundingBox": {}},
+    ]
+
+    expected_result: list[FaceDetection] = [
+        FaceDetection(confidence=99.5),
+        FaceDetection(confidence=98.2),
+    ]
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_faces = AsyncMock(
+            return_value={"FaceDetails": aws_faces}
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_faces_from_s3("test-bucket", "test-key.jpg")
+
+        assert result == expected_result
+        mock_rekognition.detect_faces.assert_awaited_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_faces_from_s3_failure() -> None:
+    """DetectFaces（S3参照版）失敗時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        error_response = {
+            "Error": {"Code": "InvalidParameterException", "Message": "API Error"}
+        }
+        mock_rekognition.detect_faces = AsyncMock(
+            side_effect=ClientError(error_response, "DetectFaces")  # type: ignore[arg-type]
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_faces_from_s3("test-bucket", "test-key.jpg")
+
+        assert "DetectFaces from S3 failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_detect_faces_from_s3_unexpected_exception() -> None:
+    """DetectFaces（S3参照版）予期しない例外のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_faces = AsyncMock(
+            side_effect=ValueError("Unexpected value error")
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_faces_from_s3("test-bucket", "test-key.jpg")
+
+        assert "Unexpected error in DetectFaces from S3" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_detect_labels_from_s3_success() -> None:
+    """DetectLabels（S3参照版）成功時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_labels = AsyncMock(return_value={"Labels": []})
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_labels_from_s3(
+            "test-bucket", "test-key.jpg", 10, 75.0
+        )
+
+        assert result == []
+        mock_rekognition.detect_labels.assert_called_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}},
+            MaxLabels=10,
+            MinConfidence=75.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_labels_from_s3_with_cat() -> None:
+    """DetectLabels（S3参照版）: 猫ラベルが検出された場合のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    aws_labels = [
+        {"Name": "Cat", "Confidence": 95.8},
+        {"Name": "Animal", "Confidence": 92.3},
+        {"Name": "Pet", "Confidence": 90.1},
+    ]
+
+    expected_result: list[LabelDetection] = [
+        LabelDetection(name="Cat", confidence=95.8),
+        LabelDetection(name="Animal", confidence=92.3),
+        LabelDetection(name="Pet", confidence=90.1),
+    ]
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_labels = AsyncMock(return_value={"Labels": aws_labels})
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        result = await service.detect_labels_from_s3(
+            "test-bucket", "test-key.jpg", 5, 80.0
+        )
+
+        assert result == expected_result
+        mock_rekognition.detect_labels.assert_called_once_with(
+            Image={"S3Object": {"Bucket": "test-bucket", "Name": "test-key.jpg"}},
+            MaxLabels=5,
+            MinConfidence=80.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_labels_from_s3_failure() -> None:
+    """DetectLabels（S3参照版）失敗時のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        error_response = {
+            "Error": {"Code": "InvalidParameterException", "Message": "API Error"}
+        }
+        mock_rekognition.detect_labels = AsyncMock(
+            side_effect=ClientError(error_response, "DetectLabels")  # type: ignore[arg-type]
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_labels_from_s3("test-bucket", "test-key.jpg", 10, 75.0)
+
+        assert "DetectLabels from S3 failed" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_detect_labels_from_s3_unexpected_exception() -> None:
+    """DetectLabels（S3参照版）予期しない例外のテスト"""
+    service = RekognitionImageAnalysisService(region="ap-northeast-1")
+
+    with patch.object(service.session, "client") as mock_client:
+        mock_rekognition = AsyncMock()
+        mock_rekognition.detect_labels = AsyncMock(
+            side_effect=TypeError("Unexpected type error")
+        )
+        mock_client.return_value.__aenter__.return_value = mock_rekognition
+
+        with pytest.raises(ErrRekognitionFailed) as exc_info:
+            await service.detect_labels_from_s3("test-bucket", "test-key.jpg", 10, 75.0)
+
+        assert "Unexpected error in DetectLabels from S3" in str(exc_info.value)

--- a/tests/usecase/test_validate_cat_image_from_s3_usecase.py
+++ b/tests/usecase/test_validate_cat_image_from_s3_usecase.py
@@ -1,0 +1,237 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+"""ValidateCatImageFromS3UseCaseのテスト"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.cat_image_validation_policy import (
+    CatImageValidationPolicy,
+    DEFAULT_VALIDATION_POLICY,
+)
+from domain.image_analysis_interface import (
+    FaceDetection,
+    LabelDetection,
+    ModerationLabelDetection,
+)
+from domain.lgtm_image_errors import ErrRekognitionFailed
+from usecase.validate_cat_image_from_s3_usecase import ValidateCatImageFromS3UseCase
+
+
+@pytest.mark.asyncio
+async def test_execute_acceptable_cat_image() -> None:
+    """受け入れ可能な猫画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=95.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/cat.jpg")
+
+    assert result["is_acceptable"] is True
+    assert "reason" not in result
+
+    # S3参照版メソッドが正しい引数で呼び出されたことを検証
+    mock_image_analysis_service.detect_moderation_labels_from_s3.assert_called_once_with(
+        "test-bucket",
+        "images/cat.jpg",
+        DEFAULT_VALIDATION_POLICY["moderation_min_confidence"],
+    )
+    mock_image_analysis_service.detect_faces_from_s3.assert_called_once_with(
+        "test-bucket", "images/cat.jpg"
+    )
+    mock_image_analysis_service.detect_labels_from_s3.assert_called_once_with(
+        "test-bucket",
+        "images/cat.jpg",
+        DEFAULT_VALIDATION_POLICY["labels_max_count"],
+        DEFAULT_VALIDATION_POLICY["labels_min_confidence"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_not_cat_image() -> None:
+    """猫が写っていない画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Dog", confidence=95.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/dog.jpg")
+
+    assert result["is_acceptable"] is False
+    assert result["reason"] == "not cat image"
+
+
+@pytest.mark.asyncio
+async def test_execute_person_face_detected() -> None:
+    """人の顔が検出された画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    # 信頼度97.0の顔を検出（96.0超でNG）
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(
+        return_value=[FaceDetection(confidence=97.0)]
+    )
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=95.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/person.jpg")
+
+    assert result["is_acceptable"] is False
+    assert result["reason"] == "person face in the image"
+
+
+@pytest.mark.asyncio
+async def test_execute_moderation_content_detected() -> None:
+    """不適切なコンテンツが検出された画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    # 不適切なコンテンツが検出された場合（空リストでない）
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[ModerationLabelDetection(name="Explicit Nudity", confidence=95.0)]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=95.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/nsfw.jpg")
+
+    assert result["is_acceptable"] is False
+    assert result["reason"] == "not moderation image"
+
+
+@pytest.mark.asyncio
+async def test_execute_rekognition_failed() -> None:
+    """Rekognitionサービス障害時は例外が伝播することをテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        side_effect=ErrRekognitionFailed("S3 object not found")
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+
+    # RekognitionエラーはキャッチせずController層に伝播する
+    with pytest.raises(ErrRekognitionFailed):
+        await usecase.execute("test-bucket", "images/invalid.jpg")
+
+
+@pytest.mark.asyncio
+async def test_execute_with_custom_policy() -> None:
+    """カスタムポリシーでのテスト"""
+    custom_policy: CatImageValidationPolicy = {
+        "moderation_min_confidence": 50.0,
+        "face_detection_min_confidence": 90.0,
+        "cat_label_min_confidence": 70.0,
+        "labels_max_count": 10,
+        "labels_min_confidence": 75.0,
+    }
+
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    # 信頼度75.0の猫ラベル（カスタムポリシーでは70.0超でOK）
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=75.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(mock_image_analysis_service, custom_policy)
+    result = await usecase.execute("test-bucket", "images/cat.jpg")
+
+    assert result["is_acceptable"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_cat_confidence_too_low() -> None:
+    """猫ラベルの信頼度が低い画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    # 信頼度80.0の猫ラベル（80.0超でないとNG）
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=80.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/cat.jpg")
+
+    assert result["is_acceptable"] is False
+    assert result["reason"] == "not cat image"
+
+
+@pytest.mark.asyncio
+async def test_execute_face_confidence_borderline() -> None:
+    """顔検出の信頼度がボーダーラインの画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    # 信頼度96.0の顔を検出（96.0超でないとNG、これはOK）
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(
+        return_value=[FaceDetection(confidence=96.0)]
+    )
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[LabelDetection(name="Cat", confidence=95.0)]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/cat.jpg")
+
+    # 96.0は96.0超ではないのでOK
+    assert result["is_acceptable"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_multiple_labels_with_cat() -> None:
+    """複数のラベルがあり、その中に猫が含まれる画像のテスト"""
+    mock_image_analysis_service = AsyncMock()
+    mock_image_analysis_service.detect_moderation_labels_from_s3 = AsyncMock(
+        return_value=[]
+    )
+    mock_image_analysis_service.detect_faces_from_s3 = AsyncMock(return_value=[])
+    mock_image_analysis_service.detect_labels_from_s3 = AsyncMock(
+        return_value=[
+            LabelDetection(name="Animal", confidence=98.0),
+            LabelDetection(name="Mammal", confidence=96.0),
+            LabelDetection(name="Cat", confidence=95.0),
+            LabelDetection(name="Pet", confidence=92.0),
+        ]
+    )
+
+    usecase = ValidateCatImageFromS3UseCase(
+        mock_image_analysis_service, DEFAULT_VALIDATION_POLICY
+    )
+    result = await usecase.execute("test-bucket", "images/cat.jpg")
+
+    assert result["is_acceptable"] is True


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/81

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- S3オブジェクトを参照した画像分析サービスの基盤実装
- Amazon Rekognitionを利用した画像分析サービス（`RekognitionImageAnalysisService`）の実装
- S3オブジェクトから猫画像を判定するユースケース（`ValidateCatImageFromS3Usecase`）の実装
- 上記に対応するユニットテストの実装

## 対応しない範囲
- APIエンドポイントの追加は別PRで対応する

# 変更点概要

S3バケット名とオブジェクトキーを指定してRekognition APIを呼び出す方式を採用した。これにより、画像データのHTTP転送が不要となり、AWS内部で直接S3オブジェクトを参照できる。

ユースケースや判定ロジックは、既存のURL指定による画像判定処理（`ValidateCatImageUsecase`）と同様の設計としている。

### 判定内容
- 不適切なコンテンツの検出（`detect_moderation_labels`）
- 人の顔の検出（`detect_faces`）
- 猫の検出（`detect_labels`）

# 補足情報

本機能は https://github.com/nekochans/lgtm-cat-processor/issues/56 の課題で必要となるAPIである。