### PR TITLE
AWS BedrockとS3 Vectorsのデフォルトリージョンを東京に変更

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -36,11 +36,11 @@ export LOG_LEVEL=INFO
 export COGNITO_REGION=ap-northeast-1
 
 # AWS Bedrock設定（埋め込みモデル用）
-export AWS_BEDROCK_REGION=us-east-1
+export AWS_BEDROCK_REGION=ap-northeast-1
 export AWS_BEDROCK_EMBEDDING_MODEL_ID=cohere.embed-v4:0
 
-# AWS S3 Vector設定（デフォルト: us-east-1）
-export S3_VECTOR_REGION=us-east-1
+# AWS S3 Vector設定（デフォルト: ap-northeast-1）
+export S3_VECTOR_REGION=ap-northeast-1
 
 # Sentry設定（エラー監視、デフォルト: 空文字）
 export SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ export LOG_LEVEL=INFO                # デフォルト: INFO（DEBUG, INFO, WARN
 export COGNITO_REGION=ap-northeast-1 # デフォルト: ap-northeast-1
 
 # AWS Bedrock設定（埋め込みモデル用）
-export AWS_BEDROCK_REGION=us-east-1  # デフォルト: us-east-1
+export AWS_BEDROCK_REGION=ap-northeast-1  # デフォルト: ap-northeast-1
 export AWS_BEDROCK_EMBEDDING_MODEL_ID=cohere.embed-v4:0  # デフォルト: cohere.embed-v4:0
 
 # AWS S3 Vector設定
-export S3_VECTOR_REGION=us-east-1    # デフォルト: us-east-1
+export S3_VECTOR_REGION=ap-northeast-1    # デフォルト: ap-northeast-1
 
 # AWS Rekognition設定（画像認識機能用）
 export AWS_REKOGNITION_REGION=ap-northeast-1  # デフォルト: ap-northeast-1

--- a/src/config.py
+++ b/src/config.py
@@ -22,13 +22,13 @@ SENTRY_DSN: Final[str] = os.getenv("SENTRY_DSN", "")
 SENTRY_ENVIRONMENT: Final[str] = os.getenv("SENTRY_ENVIRONMENT", "development")
 
 # AWS Bedrock設定
-AWS_BEDROCK_REGION: Final[str] = os.getenv("AWS_BEDROCK_REGION", "us-east-1")
+AWS_BEDROCK_REGION: Final[str] = os.getenv("AWS_BEDROCK_REGION", "ap-northeast-1")
 AWS_BEDROCK_EMBEDDING_MODEL_ID: Final[str] = os.getenv(
     "AWS_BEDROCK_EMBEDDING_MODEL_ID", "cohere.embed-v4:0"
 )
 
 # S3 Vector設定
-S3_VECTOR_REGION: Final[str] = os.getenv("S3_VECTOR_REGION", "us-east-1")
+S3_VECTOR_REGION: Final[str] = os.getenv("S3_VECTOR_REGION", "ap-northeast-1")
 _s3_vector_bucket_name: Optional[str] = os.getenv("S3_VECTOR_BUCKET_NAME")
 _s3_vector_index_name: Optional[str] = os.getenv("S3_VECTOR_INDEX_NAME")
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/86

# この PR で対応する範囲 / この PR で対応しない範囲

このPRでIssueの全ての完了条件を満たす。

# 変更点概要

AWS BedrockとS3 Vectorsのデフォルトリージョンをus-east-1からap-northeast-1（東京）に変更する。

S3 VectorsがAWS re:Invent 2025でGAとなり東京リージョンで利用可能になったため、全てのサービスを東京リージョンに統一してレイテンシを最小化する。

## 変更ファイル

- `src/config.py`: `AWS_BEDROCK_REGION`と`S3_VECTOR_REGION`のデフォルト値を変更
- `README.md`: ドキュメントの更新
- `.envrc.example`: 環境変数の例を更新