### PR TITLE
MCPツール `get_random_lgtm_markdown` を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ APIはシンプルなRESTパターンに従い、8つのエンドポイントを
 
 ### MCP Server
 
-本APIはMCP (Model Context Protocol) Serverとしても機能し、AIエージェントから直接利用できます。MCP専用エンドポイントについては上記「API設計」セクションを参照してください。
+本APIはMCP (Model Context Protocol) Serverとしても機能し、AIエージェントから直接利用できます。MCP専用エンドポイントについては上記「API仕様」セクションを参照してください。
 
 #### 利用方法
 

--- a/README.md
+++ b/README.md
@@ -223,19 +223,10 @@ APIはシンプルなRESTパターンに従い、8つのエンドポイントを
 - **トークン取得**: AWS Cognitoから発行されたアクセストークンを使用
 - **エラーレスポンス**:
   - 401 Unauthorized - トークンが無効、期限切れ、または未提供の場合
-- **認証不要**: `/mcp/lgtm-images`、`/mcp/lgtm-images/recently-created`
 
 ### MCP Server
 
-本APIはMCP (Model Context Protocol) Serverとしても機能し、AIエージェントから直接利用できます。
-
-#### MCP専用エンドポイント
-
-以下のエンドポイントは`/mcp`プレフィックス配下に公開されており、**認証不要**で利用できます：
-
-- **GET /mcp/lgtm-images** - ランダムなLGTM画像を取得
-- **GET /mcp/lgtm-images/recently-created** - 最近作成されたLGTM画像を取得
-- **GET /mcp/lgtm-images/markdown** - ランダムに1件のLGTM画像をマークダウン形式で取得
+本APIはMCP (Model Context Protocol) Serverとしても機能し、AIエージェントから直接利用できます。MCP専用エンドポイントについては上記「API設計」セクションを参照してください。
 
 #### 利用方法
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ export DATABASE_NAME=                # データベース名
 # LGTM画像のベースURL
 export LGTM_IMAGES_BASE_URL=lgtm-images.lgtmeow.com  # デフォルト: lgtm-images.lgtmeow.com
 
+# LGTMeowサイトURL（マークダウン形式のリンク先）
+export LGTMEOW_URL=https://lgtmeow.com  # デフォルト: https://lgtmeow.com
+
 # LGTM画像のアップロード先S3バケット
 export UPLOAD_S3_BUCKET_NAME=        # デフォルト: 空文字
 
@@ -207,6 +210,7 @@ APIはシンプルなRESTパターンに従い、8つのエンドポイントを
 
 1. **GET /mcp/lgtm-images** - ランダムなLGTM画像を返す
 2. **GET /mcp/lgtm-images/recently-created** - 最近作成されたLGTM画像を返す
+3. **GET /mcp/lgtm-images/markdown** - ランダムに1件のLGTM画像をマークダウン形式で返す
 
 レスポンスモデルはPydanticのBaseModelを使用して定義されており、JSONフィールドにはキャメルケースを使用します（例: `imageUrl`, `imageExtension`）。
 
@@ -231,6 +235,7 @@ APIはシンプルなRESTパターンに従い、8つのエンドポイントを
 
 - **GET /mcp/lgtm-images** - ランダムなLGTM画像を取得
 - **GET /mcp/lgtm-images/recently-created** - 最近作成されたLGTM画像を取得
+- **GET /mcp/lgtm-images/markdown** - ランダムに1件のLGTM画像をマークダウン形式で取得
 
 #### 利用方法
 

--- a/docs/plans/issue-88.md
+++ b/docs/plans/issue-88.md
@@ -102,7 +102,7 @@
   - 作業内容:
     - `exec_random_markdown(repository, base_url, lgtmeow_url)` メソッドを追加
     - `ExtractRandomLgtmMarkdownUsecase.execute(repository, base_url, lgtmeow_url)` を呼び出す
-    - 結果を `PlainTextResponse` で返す（`status_code=200`）
+    - 結果を `LgtmImageMarkdownResponse` モデルで `JSONResponse` として返す（`status_code=200`）
     - `ErrRecordCount` 例外をキャッチして 404 エラーを返す
     - その他の例外は `create_error_response` で 500 エラーを返す
 
@@ -111,7 +111,7 @@
   - 作業内容:
     - `TestLgtmImageControllerExecRandomMarkdown` クラスを追加
     - 実DB（`test_db_session`）を使用してテスト
-    - 正常系テスト: レスポンスが `PlainTextResponse` で、content-typeが `text/plain` であることを検証
+    - 正常系テスト: レスポンスが `JSONResponse` であることを検証
     - 異常系テスト: 画像が0件の場合に404エラーを返すことを検証
 
 ### 完了条件
@@ -139,16 +139,16 @@ MCPルーターに新しいエンドポイントを追加し、MCPツールと�
   - 作業内容:
     - `@router.get("/lgtm-images/markdown")` エンドポイントを追加
     - `operation_id="get_random_lgtm_markdown"` を設定
-    - `response_class=PlainTextResponse` を設定
+    - `response_model=LgtmImageMarkdownResponse` を設定
     - `summary="Get a random LGTM image in markdown format"` を設定
     - `description`: AIエージェント向けの詳細説明を追加
     - `response_description="Markdown formatted LGTM image"` を設定
     - `tags=["mcp_tool"]` を設定（MCP公開用）
     - `responses` で 200, 404, 500 の例を定義
-      - 200: `[![LGTMeow](https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp)](https://lgtmeow.com)`
+      - 200: `{"markdown": "[![LGTMeow](https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp)](https://lgtmeow.com)"}`
       - 404: `{"error": "Insufficient LGTM images available"}`
       - 500: `{"error": "Internal server error"}`
-    - `LgtmImageController.exec_random_markdown(repository, base_url)` を呼び出す
+    - `LgtmImageController.exec_random_markdown(repository, base_url, lgtmeow_url)` を呼び出す
 
 ### 完了条件
 
@@ -164,6 +164,7 @@ MCPルーターに新しいエンドポイントを追加し、MCPツールと�
 
 - `src/usecase/extract_random_lgtm_markdown_usecase.py` - 新規作成
 - `src/presentation/controller/lgtm_image_controller.py` - 新メソッド追加
+- `src/presentation/controller/lgtm_image_response.py` - `LgtmImageMarkdownResponse` モデル追加
 - `src/presentation/router/mcp_lgtm_image_router.py` - 新エンドポイント追加
 - `tests/usecase/test_extract_random_lgtm_markdown_usecase.py` - 新規作成
 - `tests/presentation/controller/test_lgtm_image_controller_exec.py` - テスト追加
@@ -182,10 +183,11 @@ MCPルーターに新しいエンドポイントを追加し、MCPツールと�
   - マークダウン変換ロジックはユースケース層に配置
   - コントローラーはユースケースを呼び出してレスポンスを返すだけ
 
-- **レスポンス形式はプレーンテキスト（`text/plain`）**
-  - `FastAPI.responses.PlainTextResponse` を使用
-  - JSONではないため、`create_json_response` は使用しない
-  - エラーレスポンス（404, 500）のみJSONResponse
+- **レスポンス形式はJSON（`application/json`）**
+  - MCP公開の手段としてFastAPI MCPを使用しており、他のエンドポイントはすべてJSON形式でレスポンスを返している
+  - `get_random_lgtm_markdown` だけが `PlainTextResponse` を返すと統一感が失われるため、JSON形式に変更
+  - `LgtmImageMarkdownResponse` モデルを使用し、`create_json_response` で返す
+  - レスポンス形式: `{"markdown": "[![LGTMeow](画像URL)](https://lgtmeow.com)"}`
 
 - **取得件数は1件のみ**
   - ユースケース内でリポジトリから直接1件取得（`repository.fetch_random_lgtm_images(limit=1)`）

--- a/docs/plans/issue-88.md
+++ b/docs/plans/issue-88.md
@@ -11,10 +11,10 @@
 
 ## 完了の定義（Issueより）
 
-- [ ] MCPツール `get_random_lgtm_markdown` が追加されている
-- [ ] ツールを呼び出すとランダムな1件のLGTM画像がマークダウン形式で返される
-- [ ] レスポンス形式は `[![LGTMeow](画像URL)](https://lgtmeow.com)` の形式である
-- [ ] 画像が取得できない場合は適切なエラーが返される
+- [x] MCPツール `get_random_lgtm_markdown` が追加されている
+- [x] ツールを呼び出すとランダムな1件のLGTM画像がマークダウン形式で返される
+- [x] レスポンス形式は `[![LGTMeow](画像URL)](https://lgtmeow.com)` の形式である
+- [x] 画像が取得できない場合は適切なエラーが返される
 
 ---
 
@@ -22,22 +22,22 @@
 
 ### テスト要件
 
-- [ ] ユースケースのテストが追加されている
-  - [ ] 正常系: マークダウン形式の文字列が返される
-  - [ ] 異常系: 画像が0件の場合に例外が発生する
-- [ ] コントローラーのテストが追加されている
-  - [ ] 正常系: マークダウン形式でレスポンスが返される
-  - [ ] 異常系: 画像が0件の場合に404エラーを返す
+- [x] ユースケースのテストが追加されている
+  - [x] 正常系: マークダウン形式の文字列が返される
+  - [x] 異常系: 画像が0件の場合に例外が発生する
+- [x] コントローラーのテストが追加されている
+  - [x] 正常系: マークダウン形式でレスポンスが返される
+  - [x] 異常系: 画像が0件の場合に404エラーを返す
 
 ### ドキュメント要件
 
-- [ ] OpenAPI仕様が自動生成される（コード内のdocstringで対応）
+- [x] OpenAPI仕様が自動生成される（コード内のdocstringで対応）
 
 ### 品質要件（固定）
 
-- [ ] `make lint` が通る
-- [ ] `make typecheck` が通る
-- [ ] `make test` が通る
+- [x] `make lint` が通る
+- [x] `make typecheck` が通る
+- [x] `make test` が通る
 
 ---
 
@@ -59,7 +59,7 @@
 
 ### タスク一覧
 
-- [ ] **Task 1.1**: ユースケースの追加
+- [x] **Task 1.1**: ユースケースの追加
   - 対象ファイル: `src/usecase/extract_random_lgtm_markdown_usecase.py`（新規作成）
   - 作業内容:
     - `ExtractRandomLgtmMarkdownUsecase` クラスを作成
@@ -97,16 +97,16 @@
 
 ### タスク一覧
 
-- [ ] **Task 2.1**: コントローラーメソッドの追加
+- [x] **Task 2.1**: コントローラーメソッドの追加
   - 対象ファイル: `src/presentation/controller/lgtm_image_controller.py`
   - 作業内容:
-    - `exec_random_markdown(repository, base_url)` メソッドを追加
-    - `ExtractRandomLgtmMarkdownUsecase.execute(repository, base_url)` を呼び出す
+    - `exec_random_markdown(repository, base_url, lgtmeow_url)` メソッドを追加
+    - `ExtractRandomLgtmMarkdownUsecase.execute(repository, base_url, lgtmeow_url)` を呼び出す
     - 結果を `PlainTextResponse` で返す（`status_code=200`）
     - `ErrRecordCount` 例外をキャッチして 404 エラーを返す
     - その他の例外は `create_error_response` で 500 エラーを返す
 
-- [ ] **Task 2.2**: コントローラーテストの追加
+- [x] **Task 2.2**: コントローラーテストの追加
   - 対象ファイル: `tests/presentation/controller/test_lgtm_image_controller_exec.py`
   - 作業内容:
     - `TestLgtmImageControllerExecRandomMarkdown` クラスを追加
@@ -116,9 +116,9 @@
 
 ### 完了条件
 
-- [ ] コントローラーメソッドがユースケースを呼び出してレスポンスを返す
-- [ ] テストがすべてパスする
-- [ ] 品質チェックが通る
+- [x] コントローラーメソッドがユースケースを呼び出してレスポンスを返す
+- [x] テストがすべてパスする
+- [x] 品質チェックが通る
 
 ---
 
@@ -134,7 +134,7 @@ MCPルーターに新しいエンドポイントを追加し、MCPツールと�
 
 ### タスク一覧
 
-- [ ] **Task 3.1**: MCPルーターにエンドポイントを追加
+- [x] **Task 3.1**: MCPルーターにエンドポイントを追加
   - 対象ファイル: `src/presentation/router/mcp_lgtm_image_router.py`
   - 作業内容:
     - `@router.get("/lgtm-images/markdown")` エンドポイントを追加
@@ -152,9 +152,9 @@ MCPルーターに新しいエンドポイントを追加し、MCPツールと�
 
 ### 完了条件
 
-- [ ] MCPツールとしてエンドポイントが公開される
-- [ ] OpenAPIドキュメントに仕様が反映される
-- [ ] 品質チェックが通る
+- [x] MCPツールとしてエンドポイントが公開される
+- [x] OpenAPIドキュメントに仕様が反映される
+- [x] 品質チェックが通る
 
 ---
 

--- a/docs/plans/issue-88.md
+++ b/docs/plans/issue-88.md
@@ -1,0 +1,206 @@
+# 実行計画: Issue #88 - MCPツール `get_random_lgtm_markdown` を追加する
+
+## Issue情報
+
+- **Issue URL**: https://github.com/nekochans/lgtm-cat-api/issues/88
+- **作成日**: 2025-12-08
+
+## 概要
+
+ランダムなLGTM画像をマークダウン形式で返すMCPツール `get_random_lgtm_markdown` を追加する。AIエージェントがコードレビューやPR承認コメントで直接利用できるよう、マークダウン形式のレスポンスを提供する。
+
+## 完了の定義（Issueより）
+
+- [ ] MCPツール `get_random_lgtm_markdown` が追加されている
+- [ ] ツールを呼び出すとランダムな1件のLGTM画像がマークダウン形式で返される
+- [ ] レスポンス形式は `[![LGTMeow](画像URL)](https://lgtmeow.com)` の形式である
+- [ ] 画像が取得できない場合は適切なエラーが返される
+
+---
+
+## 完了要件
+
+### テスト要件
+
+- [ ] ユースケースのテストが追加されている
+  - [ ] 正常系: マークダウン形式の文字列が返される
+  - [ ] 異常系: 画像が0件の場合に例外が発生する
+- [ ] コントローラーのテストが追加されている
+  - [ ] 正常系: マークダウン形式でレスポンスが返される
+  - [ ] 異常系: 画像が0件の場合に404エラーを返す
+
+### ドキュメント要件
+
+- [ ] OpenAPI仕様が自動生成される（コード内のdocstringで対応）
+
+### 品質要件（固定）
+
+- [ ] `make lint` が通る
+- [ ] `make typecheck` が通る
+- [ ] `make test` が通る
+
+---
+
+## フェーズ構成
+
+| フェーズ | 説明 | タスク数 |
+|---------|------|---------|
+| Phase 1 | ユースケース層の実装 | 2 |
+| Phase 2 | コントローラー層の実装 | 2 |
+| Phase 3 | プレゼンテーション層の実装 | 1 |
+
+---
+
+## Phase 1: ユースケース層の実装
+
+### 目的
+
+マークダウン形式でランダムLGTM画像を取得するユースケースを実装する。
+
+### タスク一覧
+
+- [ ] **Task 1.1**: ユースケースの追加
+  - 対象ファイル: `src/usecase/extract_random_lgtm_markdown_usecase.py`（新規作成）
+  - 作業内容:
+    - `ExtractRandomLgtmMarkdownUsecase` クラスを作成
+    - `execute(repository, base_url)` 静的メソッドを実装
+    - リポジトリから直接1件取得（`repository.fetch_random_lgtm_images(limit=1)`）
+    - 取得件数が0件の場合は `ErrRecordCount` を発生させる
+    - 取得した画像URLを `[![LGTMeow]({url})](https://lgtmeow.com)` 形式に変換して返す
+    - 戻り値の型は `str`（マークダウン文字列）
+
+- [ ] **Task 1.2**: ユースケーステストの追加
+  - 対象ファイル: `tests/usecase/test_extract_random_lgtm_markdown_usecase.py`（新規作成）
+  - 作業内容:
+    - 実DB（`test_db_session`）を使用してテスト
+    - 正常系テスト: 返り値がマークダウン形式の文字列であることを検証
+    - 正常系テスト: `[![LGTMeow]({url})](https://lgtmeow.com)` 形式であることを検証
+    - 異常系テスト: 画像が0件の場合に `ErrRecordCount` が発生することを検証
+
+### 完了条件
+
+- [ ] ユースケースがマークダウン形式の文字列を返す
+- [ ] テストがすべてパスする
+- [ ] 品質チェックが通る
+
+---
+
+## Phase 2: コントローラー層の実装
+
+### 目的
+
+ユースケースを呼び出し、レスポンスを返すコントローラーメソッドを実装する。
+
+### 依存関係
+
+- Phase 1 の完了が必要
+
+### タスク一覧
+
+- [ ] **Task 2.1**: コントローラーメソッドの追加
+  - 対象ファイル: `src/presentation/controller/lgtm_image_controller.py`
+  - 作業内容:
+    - `exec_random_markdown(repository, base_url)` メソッドを追加
+    - `ExtractRandomLgtmMarkdownUsecase.execute(repository, base_url)` を呼び出す
+    - 結果を `PlainTextResponse` で返す（`status_code=200`）
+    - `ErrRecordCount` 例外をキャッチして 404 エラーを返す
+    - その他の例外は `create_error_response` で 500 エラーを返す
+
+- [ ] **Task 2.2**: コントローラーテストの追加
+  - 対象ファイル: `tests/presentation/controller/test_lgtm_image_controller_exec.py`
+  - 作業内容:
+    - `TestLgtmImageControllerExecRandomMarkdown` クラスを追加
+    - 実DB（`test_db_session`）を使用してテスト
+    - 正常系テスト: レスポンスが `PlainTextResponse` で、content-typeが `text/plain` であることを検証
+    - 異常系テスト: 画像が0件の場合に404エラーを返すことを検証
+
+### 完了条件
+
+- [ ] コントローラーメソッドがユースケースを呼び出してレスポンスを返す
+- [ ] テストがすべてパスする
+- [ ] 品質チェックが通る
+
+---
+
+## Phase 3: プレゼンテーション層の実装
+
+### 目的
+
+MCPルーターに新しいエンドポイントを追加し、MCPツールとして公開する。
+
+### 依存関係
+
+- Phase 2 の完了が必要
+
+### タスク一覧
+
+- [ ] **Task 3.1**: MCPルーターにエンドポイントを追加
+  - 対象ファイル: `src/presentation/router/mcp_lgtm_image_router.py`
+  - 作業内容:
+    - `@router.get("/lgtm-images/markdown")` エンドポイントを追加
+    - `operation_id="get_random_lgtm_markdown"` を設定
+    - `response_class=PlainTextResponse` を設定
+    - `summary="Get a random LGTM image in markdown format"` を設定
+    - `description`: AIエージェント向けの詳細説明を追加
+    - `response_description="Markdown formatted LGTM image"` を設定
+    - `tags=["mcp_tool"]` を設定（MCP公開用）
+    - `responses` で 200, 404, 500 の例を定義
+      - 200: `[![LGTMeow](https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp)](https://lgtmeow.com)`
+      - 404: `{"error": "Insufficient LGTM images available"}`
+      - 500: `{"error": "Internal server error"}`
+    - `LgtmImageController.exec_random_markdown(repository, base_url)` を呼び出す
+
+### 完了条件
+
+- [ ] MCPツールとしてエンドポイントが公開される
+- [ ] OpenAPIドキュメントに仕様が反映される
+- [ ] 品質チェックが通る
+
+---
+
+## 実装メモ
+
+### 影響を受けるファイル
+
+- `src/usecase/extract_random_lgtm_markdown_usecase.py` - 新規作成
+- `src/presentation/controller/lgtm_image_controller.py` - 新メソッド追加
+- `src/presentation/router/mcp_lgtm_image_router.py` - 新エンドポイント追加
+- `tests/usecase/test_extract_random_lgtm_markdown_usecase.py` - 新規作成
+- `tests/presentation/controller/test_lgtm_image_controller_exec.py` - テスト追加
+
+### 参考にすべき既存コード
+
+- `src/usecase/extract_random_lgtm_images_usecase.py` - ユースケースのパターン
+- `src/presentation/controller/lgtm_image_controller.py` の `exec()` メソッド - コントローラーパターン
+- `src/presentation/router/mcp_lgtm_image_router.py` の既存エンドポイント - ルーター定義パターン
+- `tests/usecase/test_extract_random_lgtm_images_usecase.py` - ユースケーステストパターン
+- `tests/presentation/controller/test_lgtm_image_controller_exec.py` の既存テスト - コントローラーテストパターン
+
+### 注意点
+
+- **責務の分離**
+  - マークダウン変換ロジックはユースケース層に配置
+  - コントローラーはユースケースを呼び出してレスポンスを返すだけ
+
+- **レスポンス形式はプレーンテキスト（`text/plain`）**
+  - `FastAPI.responses.PlainTextResponse` を使用
+  - JSONではないため、`create_json_response` は使用しない
+  - エラーレスポンス（404, 500）のみJSONResponse
+
+- **取得件数は1件のみ**
+  - ユースケース内でリポジトリから直接1件取得（`repository.fetch_random_lgtm_images(limit=1)`）
+  - 他のユースケースは呼び出さない（ユースケース間の依存を避ける）
+
+- **マークダウン形式**
+  - `[![LGTMeow](画像URL)](https://lgtmeow.com)` の形式に厳密に従う
+  - 画像のalt textは "LGTMeow" 固定
+  - リンク先は "https://lgtmeow.com" 固定
+
+- **エラーハンドリング**
+  - ユースケース層: `ErrRecordCount` をそのまま伝播
+  - コントローラー層: `ErrRecordCount` をキャッチして 404、その他は 500
+
+- **型アノテーション**
+  - すべての関数に適切な型アノテーションを付ける
+  - `mypy --strict` を通過する必要がある
+

--- a/src/config.py
+++ b/src/config.py
@@ -122,6 +122,15 @@ def get_sentry_environment() -> str:
     return SENTRY_ENVIRONMENT
 
 
+# LGTMeow URL設定
+LGTMEOW_URL: Final[str] = os.getenv("LGTMEOW_URL", "https://lgtmeow.com")
+
+
+def get_lgtmeow_url() -> str:
+    """LGTMeowのURLを取得"""
+    return LGTMEOW_URL
+
+
 # 画像取得設定
 # HTTPリクエストのタイムアウト（秒）
 IMAGE_FETCH_TIMEOUT: Final[int] = 5

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from domain.repository.lgtm_image_search_repository_interface import (
     LgtmImageSearchRepositoryInterface,
 )
-from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi.responses import JSONResponse
 
 from domain.lgtm_image import LgtmImage
 from domain.lgtm_image_errors import (
@@ -30,6 +30,7 @@ from presentation.controller.lgtm_image_request import (
 from presentation.controller.lgtm_image_response import (
     LgtmImageCreateResponse,
     LgtmImageItem,
+    LgtmImageMarkdownResponse,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
     LgtmImageSearchByImageResponse,
@@ -180,14 +181,15 @@ class LgtmImageController:
         repository: LgtmImageRepositoryInterface,
         base_url: str,
         lgtmeow_url: str,
-    ) -> PlainTextResponse | JSONResponse:
+    ) -> JSONResponse:
         logger.info("Extracting random LGTM image as markdown")
 
         try:
             markdown: str = await ExtractRandomLgtmMarkdownUsecase.execute(
                 repository, base_url, lgtmeow_url
             )
-            return PlainTextResponse(content=markdown, status_code=200)
+            response = LgtmImageMarkdownResponse(markdown=markdown)
+            return create_json_response(response)
         except ErrRecordCount:
             logger.error("Insufficient LGTM images available")
             return JSONResponse(

--- a/src/presentation/controller/lgtm_image_controller.py
+++ b/src/presentation/controller/lgtm_image_controller.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from domain.repository.lgtm_image_search_repository_interface import (
     LgtmImageSearchRepositoryInterface,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from domain.lgtm_image import LgtmImage
 from domain.lgtm_image_errors import (
@@ -46,6 +46,9 @@ from usecase.create_lgtm_image_from_url_usecase import (
 from usecase.create_lgtm_image_usecase import CreateLgtmImageUsecase
 from usecase.extract_random_lgtm_images_usecase import (
     ExtractRandomLgtmImagesUsecase,
+)
+from usecase.extract_random_lgtm_markdown_usecase import (
+    ExtractRandomLgtmMarkdownUsecase,
 )
 from usecase.retrieve_recently_created_lgtm_images_usecase import (
     RetrieveRecentlyCreatedLgtmImagesUsecase,
@@ -170,6 +173,29 @@ class LgtmImageController:
             )
         except Exception as e:
             logger.error(f"Error extracting random LGTM images: {e}")
+            return create_error_response(e)
+
+    @staticmethod
+    async def exec_random_markdown(
+        repository: LgtmImageRepositoryInterface,
+        base_url: str,
+        lgtmeow_url: str,
+    ) -> PlainTextResponse | JSONResponse:
+        logger.info("Extracting random LGTM image as markdown")
+
+        try:
+            markdown: str = await ExtractRandomLgtmMarkdownUsecase.execute(
+                repository, base_url, lgtmeow_url
+            )
+            return PlainTextResponse(content=markdown, status_code=200)
+        except ErrRecordCount:
+            logger.error("Insufficient LGTM images available")
+            return JSONResponse(
+                status_code=404,
+                content={"error": "Insufficient LGTM images available"},
+            )
+        except Exception as e:
+            logger.error(f"Error extracting random LGTM markdown: {e}")
             return create_error_response(e)
 
     @staticmethod

--- a/src/presentation/controller/lgtm_image_response.py
+++ b/src/presentation/controller/lgtm_image_response.py
@@ -124,3 +124,13 @@ class LgtmImageSearchByImageResponse(BaseModel):
             ]
         ],
     )
+
+
+class LgtmImageMarkdownResponse(BaseModel):
+    markdown: str = Field(
+        ...,
+        description="LGTM画像のマークダウン形式",
+        examples=[
+            "[![LGTMeow](https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp)](https://lgtmeow.com)"
+        ],
+    )

--- a/src/presentation/router/mcp_lgtm_image_router.py
+++ b/src/presentation/router/mcp_lgtm_image_router.py
@@ -3,14 +3,14 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from presentation.controller.lgtm_image_response import (
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from config import get_lgtm_images_base_url
+from config import get_lgtm_images_base_url, get_lgtmeow_url
 from domain.repository.lgtm_image_repository_interface import (
     LgtmImageRepositoryInterface,
 )
@@ -131,3 +131,49 @@ async def retrieve_recently_created_lgtm_images(
     base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
 ) -> JSONResponse:
     return await LgtmImageController.exec_recently_created(repository, base_url)
+
+
+@router.get(
+    "/lgtm-images/markdown",
+    summary="Get a random LGTM image in markdown format",
+    description="Returns a single randomly selected LGTM (Looks Good To Me) cat image in markdown format for use in code review comments and pull request approvals.",
+    response_description="Markdown formatted LGTM image",
+    response_class=PlainTextResponse,
+    response_model=None,
+    tags=["mcp_tool"],
+    operation_id="get_random_lgtm_markdown",
+    responses={
+        200: {
+            "description": "Success Response - Markdown formatted LGTM image",
+            "content": {
+                "text/plain": {
+                    "example": "[![LGTMeow](https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp)](https://lgtmeow.com)"
+                }
+            },
+        },
+        404: {
+            "description": "No LGTM images found",
+            "content": {
+                "application/json": {
+                    "example": {"error": "Insufficient LGTM images available"}
+                }
+            },
+        },
+        500: {
+            "description": "Internal server error",
+            "content": {
+                "application/json": {"example": {"error": "Internal server error"}}
+            },
+        },
+    },
+)
+async def get_random_lgtm_markdown(
+    repository: Annotated[
+        LgtmImageRepositoryInterface, Depends(create_lgtm_image_repository)
+    ],
+    base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
+    lgtmeow_url: Annotated[str, Depends(get_lgtmeow_url)],
+) -> PlainTextResponse | JSONResponse:
+    return await LgtmImageController.exec_random_markdown(
+        repository, base_url, lgtmeow_url
+    )

--- a/src/presentation/router/mcp_lgtm_image_router.py
+++ b/src/presentation/router/mcp_lgtm_image_router.py
@@ -3,8 +3,9 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi.responses import JSONResponse
 from presentation.controller.lgtm_image_response import (
+    LgtmImageMarkdownResponse,
     LgtmImageRandomListResponse,
     LgtmImageRecentlyCreatedListResponse,
 )
@@ -138,16 +139,17 @@ async def retrieve_recently_created_lgtm_images(
     summary="Get a random LGTM image in markdown format",
     description="Returns a single randomly selected LGTM (Looks Good To Me) cat image in markdown format for use in code review comments and pull request approvals.",
     response_description="Markdown formatted LGTM image",
-    response_class=PlainTextResponse,
-    response_model=None,
+    response_model=LgtmImageMarkdownResponse,
     tags=["mcp_tool"],
     operation_id="get_random_lgtm_markdown",
     responses={
         200: {
             "description": "Success Response - Markdown formatted LGTM image",
             "content": {
-                "text/plain": {
-                    "example": "[![LGTMeow](https://lgtm-images.lgtmeow.com/2021/03/16/23/5947f291-a46e-453c-a230-0d756d7174cb.webp)](https://lgtmeow.com)"
+                "application/json": {
+                    "example": {
+                        "markdown": "[![LGTMeow](https://lgtm-images.lgtmeow.com/2022/03/23/10/9738095a-f426-48e4-be8d-93f933c42917.webp)](https://lgtmeow.com)"
+                    }
                 }
             },
         },
@@ -173,7 +175,7 @@ async def get_random_lgtm_markdown(
     ],
     base_url: Annotated[str, Depends(get_lgtm_images_base_url)],
     lgtmeow_url: Annotated[str, Depends(get_lgtmeow_url)],
-) -> PlainTextResponse | JSONResponse:
+) -> JSONResponse:
     return await LgtmImageController.exec_random_markdown(
         repository, base_url, lgtmeow_url
     )

--- a/src/usecase/extract_random_lgtm_markdown_usecase.py
+++ b/src/usecase/extract_random_lgtm_markdown_usecase.py
@@ -1,0 +1,45 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+import random
+
+from domain.lgtm_image_errors import ErrRecordCount
+from domain.lgtm_image_object import create_lgtm_image
+from domain.repository.lgtm_image_repository_interface import (
+    LgtmImageRepositoryInterface,
+)
+from log.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ExtractRandomLgtmMarkdownUsecase:
+    @staticmethod
+    async def execute(
+        repository: LgtmImageRepositoryInterface,
+        base_url: str,
+        lgtmeow_url: str,
+    ) -> str:
+        logger.info("Executing ExtractRandomLgtmMarkdownUsecase")
+
+        ids = await repository.find_all_ids()
+
+        if len(ids) < 1:
+            raise ErrRecordCount()
+
+        random_id = random.choice(ids)
+
+        image_objects = await repository.find_by_ids([random_id])
+
+        if len(image_objects) == 0:
+            raise ErrRecordCount()
+
+        lgtm_image = create_lgtm_image(image_objects[0], base_url)
+
+        markdown = f"[![LGTMeow]({lgtm_image['url']})]({lgtmeow_url})"
+
+        logger.info(
+            "ExtractRandomLgtmMarkdownUsecase completed successfully",
+            extra={"markdown": markdown},
+        )
+
+        return markdown

--- a/tests/presentation/controller/test_lgtm_image_controller_exec.py
+++ b/tests/presentation/controller/test_lgtm_image_controller_exec.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi.responses import JSONResponse
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -336,7 +336,7 @@ class TestLgtmImageControllerExecRandomMarkdown:
     async def test_exec_random_markdown_success(
         self, test_db_session: AsyncSession
     ) -> None:
-        """正常系: マークダウン形式のレスポンスを返す."""
+        """正常系: マークダウン形式のJSONレスポンスを返す."""
         # Arrange - DBに10件のテストデータを挿入
         await insert_test_lgtm_images(test_db_session, count=10)
 
@@ -351,18 +351,17 @@ class TestLgtmImageControllerExecRandomMarkdown:
             lgtmeow_url=lgtmeow_url,
         )
 
-        # Assert - PlainTextResponseを返すことを検証
-        assert isinstance(result, PlainTextResponse)
+        # Assert - JSONResponseを返すことを検証
+        assert isinstance(result, JSONResponse)
         assert result.status_code == 200
 
-        # Assert - content-typeが text/plain; charset=utf-8 であることを検証
-        assert result.media_type == "text/plain"
-
         # Assert - レスポンス内容がマークダウン形式であることを検証
-        content = bytes(result.body).decode("utf-8")
-        assert content.startswith("[![LGTMeow](")
-        assert content.endswith(f")]({lgtmeow_url})")
-        assert f"https://{base_url}" in content
+        content = json.loads(bytes(result.body).decode("utf-8"))
+        assert "markdown" in content
+        markdown_value = content["markdown"]
+        assert markdown_value.startswith("[![LGTMeow](")
+        assert markdown_value.endswith(f")]({lgtmeow_url})")
+        assert f"https://{base_url}" in markdown_value
 
     @pytest.mark.asyncio
     async def test_exec_random_markdown_raises_error_when_no_records(

--- a/tests/presentation/controller/test_lgtm_image_controller_exec.py
+++ b/tests/presentation/controller/test_lgtm_image_controller_exec.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -316,6 +316,96 @@ class TestLgtmImageControllerExecRecentlyCreated:
         result = await LgtmImageController.exec_recently_created(
             repository=repository,
             base_url=base_url,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert "Internal server error" in content["error"]
+
+
+class TestLgtmImageControllerExecRandomMarkdown:
+    """LgtmImageController.exec_random_markdown() のテスト.
+
+    内部DBのみに依存するため、実DB（test_db_session）を使用してテストする。
+    """
+
+    @pytest.mark.asyncio
+    async def test_exec_random_markdown_success(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """正常系: マークダウン形式のレスポンスを返す."""
+        # Arrange - DBに10件のテストデータを挿入
+        await insert_test_lgtm_images(test_db_session, count=10)
+
+        repository = LgtmImageRepository(test_db_session)
+        base_url = "cdn.example.com"
+        lgtmeow_url = "https://lgtmeow.com"
+
+        # Act
+        result = await LgtmImageController.exec_random_markdown(
+            repository=repository,
+            base_url=base_url,
+            lgtmeow_url=lgtmeow_url,
+        )
+
+        # Assert - PlainTextResponseを返すことを検証
+        assert isinstance(result, PlainTextResponse)
+        assert result.status_code == 200
+
+        # Assert - content-typeが text/plain; charset=utf-8 であることを検証
+        assert result.media_type == "text/plain"
+
+        # Assert - レスポンス内容がマークダウン形式であることを検証
+        content = bytes(result.body).decode("utf-8")
+        assert content.startswith("[![LGTMeow](")
+        assert content.endswith(f")]({lgtmeow_url})")
+        assert f"https://{base_url}" in content
+
+    @pytest.mark.asyncio
+    async def test_exec_random_markdown_raises_error_when_no_records(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """異常系: レコードが0件の場合に404を返す."""
+        # Arrange - DBにデータを挿入しない（0件）
+        repository = LgtmImageRepository(test_db_session)
+        base_url = "example.com"
+        lgtmeow_url = "https://lgtmeow.com"
+
+        # Act
+        result = await LgtmImageController.exec_random_markdown(
+            repository=repository,
+            base_url=base_url,
+            lgtmeow_url=lgtmeow_url,
+        )
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 404
+        content = json.loads(bytes(result.body))
+        assert "error" in content
+        assert content["error"] == "Insufficient LGTM images available"
+
+    @pytest.mark.asyncio
+    async def test_exec_random_markdown_propagates_repository_errors(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """異常系: リポジトリのエラーで500を返す."""
+        # Arrange - lgtm_imagesテーブルを削除してDBエラーを発生させる
+        await test_db_session.execute(text("DROP TABLE IF EXISTS lgtm_images"))
+        await test_db_session.commit()
+
+        repository = LgtmImageRepository(test_db_session)
+        base_url = "example.com"
+        lgtmeow_url = "https://lgtmeow.com"
+
+        # Act
+        result = await LgtmImageController.exec_random_markdown(
+            repository=repository,
+            base_url=base_url,
+            lgtmeow_url=lgtmeow_url,
         )
 
         # Assert

--- a/tests/usecase/test_extract_random_lgtm_markdown_usecase.py
+++ b/tests/usecase/test_extract_random_lgtm_markdown_usecase.py
@@ -1,0 +1,62 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+import random
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.lgtm_image_errors import ErrRecordCount
+from infrastructure.lgtm_image_repository import LgtmImageRepository
+from tests.fixtures.test_data_helpers import insert_test_lgtm_images
+from usecase.extract_random_lgtm_markdown_usecase import (
+    ExtractRandomLgtmMarkdownUsecase,
+)
+
+
+class TestExtractRandomLgtmMarkdownUsecase:
+    @pytest.mark.asyncio
+    async def test_execute_returns_markdown_format(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """正常系: [![LGTMeow](url)](https://lgtmeow.com) 形式の文字列を返すことを検証."""
+        # Arrange - DBに10件のテストデータを挿入
+        await insert_test_lgtm_images(test_db_session, count=10)
+
+        repository = LgtmImageRepository(test_db_session)
+        base_url = "example.com"
+        lgtmeow_url = "https://lgtmeow.com"
+        random.seed(42)  # ランダム性を固定
+
+        # Act
+        result = await ExtractRandomLgtmMarkdownUsecase.execute(
+            repository=repository,
+            base_url=base_url,
+            lgtmeow_url=lgtmeow_url,
+        )
+
+        # Assert - 文字列型であることを検証
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+        # Assert - マークダウン形式のフォーマット検証
+        assert result.startswith("[![LGTMeow](")
+        assert result.endswith(")](https://lgtmeow.com)")
+        assert f"https://{base_url}" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_err_record_count_when_no_images(
+        self, test_db_session: AsyncSession
+    ) -> None:
+        """異常系: 画像が0件の場合にErrRecordCountが発生することを検証."""
+        # Arrange - テストデータを挿入しない（0件）
+        repository = LgtmImageRepository(test_db_session)
+        base_url = "example.com"
+        lgtmeow_url = "https://lgtmeow.com"
+
+        # Act & Assert
+        with pytest.raises(ErrRecordCount):
+            await ExtractRandomLgtmMarkdownUsecase.execute(
+                repository=repository,
+                base_url=base_url,
+                lgtmeow_url=lgtmeow_url,
+            )


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/88

# この PR で対応する範囲 / この PR で対応しない範囲

Issue #88 の完了条件をすべて実装している。

# 変更点概要

AIエージェントがLGTM画像をコードレビューやPR承認コメントで利用する際に、取得した結果をそのまま貼り付けられるようにするため、ランダムなLGTM画像をマークダウン形式で返すMCPツールを追加した。

レスポンスは `[![LGTMeow](画像URL)](https://lgtmeow.com)` 形式のプレーンテキストで返す。

# レビュアーに重点的にチェックして欲しい点

- MCPツール名の説明は適切か