### PR TITLE
MCP Streamable HTTPトランスポートを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,18 +248,21 @@ make run
 本APIは以下のトランスポート方式に対応しています：
 
 - **SSE (Server-Sent Events)** - エンドポイント: `/sse` (後方互換性のため維持)
+- **Streamable HTTP** - エンドポイント: `/mcp` (MCP仕様 2025-03-26 準拠、本番環境推奨)
 
 #### MCPクライアント設定
 
 MCPに対応したクライアントから接続できます。以下はClaudeでの設定例です。
 
-##### Claude Desktopの設定（SSEトランスポート）
+##### Claude Desktopの設定
 
 設定ファイル（`claude_desktop_config.json`）に以下を追加してください：
 
 **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+**SSEトランスポートを使う場合（レガシー）:**
 
 ```json
 {
@@ -275,6 +278,24 @@ MCPに対応したクライアントから接続できます。以下はClaude�
 }
 ```
 
+**Streamable HTTPトランスポートを使う場合（推奨）:**
+
+```json
+{
+  "mcpServers": {
+    "lgtmeow": {
+      "command": "/path/to/uvx",
+      "args": [
+        "mcp-proxy",
+        "--transport",
+        "streamablehttp",
+        "http://localhost:8000/mcp"
+      ]
+    }
+  }
+}
+```
+
 **必要な設定:**
 
 - [uv](https://docs.astral.sh/uv/)のインストールが必要です
@@ -282,9 +303,11 @@ MCPに対応したクライアントから接続できます。以下はClaude�
 
 設定後、Claude Desktopを再起動すると利用可能になります。
 
-##### Claude Codeの設定（SSEトランスポート）
+##### Claude Codeの設定
 
 プロジェクトルートに`.mcp.json`ファイルを作成し、以下を追加してください：
+
+**SSEトランスポートを使う場合（レガシー）:**
 
 ```json
 {
@@ -297,7 +320,20 @@ MCPに対応したクライアントから接続できます。以下はClaude�
 }
 ```
 
-Claude Codeはプロキシを必要とせず、SSEエンドポイントに直接接続できます。Claude Codeを起動すると自動的にMCPサーバーが認識されます。
+**Streamable HTTPトランスポートを使う場合（推奨）:**
+
+```json
+{
+  "mcpServers": {
+    "lgtmeow": {
+      "type": "http",
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+Claude Codeはプロキシを必要とせず、MCPエンドポイントに直接接続できます。Claude Codeを起動すると自動的にMCPサーバーが認識されます。
 
 ## プロジェクト構造
 

--- a/docs/plans/issue-93.md
+++ b/docs/plans/issue-93.md
@@ -14,13 +14,13 @@
 - [x] `fastapi-mcp` への依存が完全に除去されている
 - [x] MCP公式Python SDK (`modelcontextprotocol/python-sdk`) を使用してMCP Serverが実装されている
 - [x] 既存のSSEトランスポート (`/sse`) が引き続き動作する（後方互換性の維持）
-- [ ] Streamable HTTPトランスポートが追加されている
+- [x] Streamable HTTPトランスポートが追加されている
 - [x] 既存の3つのMCPツールが同じツール名・スキーマで動作する
   - `get_random_lgtm_images`
   - `get_recently_created_lgtm_images`
   - `get_random_lgtm_markdown`
 - [x] 既存のREST APIエンドポイント（認証が必要なもの）に影響がない
-- [ ] ミドルウェアのスキップ処理が新しいトランスポートのパスにも対応している
+- [x] ミドルウェアのスキップ処理が新しいトランスポートのパスにも対応している
 
 ---
 
@@ -47,9 +47,9 @@
 
 ### 品質要件（固定）
 
-- [ ] `make lint` が通る
-- [ ] `make typecheck` が通る
-- [ ] `make test` が通る
+- [x] `make lint` が通る
+- [x] `make typecheck` が通る
+- [x] `make test` が通る
 
 ---
 
@@ -142,33 +142,35 @@ MCP仕様 2025-03-26 リビジョンで正式導入された Streamable HTTP ト
 
 ### タスク一覧
 
-- [ ] **Task 2.1**: Streamable HTTPトランスポートの実装
-  - 対象ファイル: `src/presentation/router/mcp_http_router.py`（新規作成）
+- [x] **Task 2.1**: Streamable HTTPトランスポートの実装
+  - 対象ファイル: `src/presentation/mcp/mcp_http_transport.py`（新規作成）
   - 作業内容:
-    - FastAPIのAPIRouterでHTTPエンドポイント (`/mcp`) を実装
-    - MCP公式SDKのStreamable HTTPトランスポート機能を使用
+    - MCP公式SDKの`StreamableHTTPSessionManager`を使用してHTTPトランスポートを実装
+    - `/mcp`パスでASGIアプリとして提供（`app.mount()`でマウント）
     - Phase 1で作成したMCP Serverインスタンスを再利用
+    - `main.py`のlifespanで`session_manager.run()`を呼び出してタスクグループを初期化
 
-- [ ] **Task 2.2**: ミドルウェアのスキップ処理更新
+- [x] **Task 2.2**: ミドルウェアのスキップ処理更新
   - 対象ファイル: `src/presentation/middleware/logging_middleware.py`, `src/presentation/middleware/request_id_middleware.py`
   - 作業内容:
     - `/mcp`パスもスキップするように条件を追加
     - 既存の`/sse`スキップ処理と統合（`/sse`または`/mcp`）
 
-- [ ] **Task 2.3**: main.pyの更新とドキュメント整備
+- [x] **Task 2.3**: main.pyの更新とドキュメント整備
   - 対象ファイル: `src/main.py`, `README.md`
   - 作業内容:
-    - 新しいHTTPルーター (`mcp_http_router`) を登録
+    - `mcp_http_transport`をインポートし、`app.mount("/mcp", mcp_http_transport.http_app)`でマウント
+    - `lifespan`関数で`mcp_http_transport.session_manager.run()`を呼び出してタスクグループを初期化
     - README.mdにStreamable HTTPトランスポートの設定例を追加
     - MCPクライアント設定例を両方のトランスポート（SSE、HTTP）に対応
 
 ### 完了条件
 
-- [ ] Streamable HTTPトランスポート (`/mcp`) が動作する
-- [ ] ミドルウェアのスキップ処理が `/mcp` パスにも対応している
-- [ ] README.mdにStreamable HTTPトランスポートの設定例が追加されている
-- [ ] SSEトランスポートも引き続き動作する（両方のトランスポートが共存）
-- [ ] 品質チェックが通る
+- [x] Streamable HTTPトランスポート (`/mcp`) が動作する（実装完了、手動確認推奨）
+- [x] ミドルウェアのスキップ処理が `/mcp` パスにも対応している
+- [x] README.mdにStreamable HTTPトランスポートの設定例が追加されている
+- [x] SSEトランスポートも引き続き動作する（両方のトランスポートが共存）
+- [x] 品質チェックが通る（lint, typecheck, test全て通過）
 
 ---
 
@@ -184,10 +186,10 @@ MCP仕様 2025-03-26 リビジョンで正式導入された Streamable HTTP ト
 - `README.md` - MCP設定例更新
 
 #### Phase 2（PR #2）
-- `src/presentation/router/mcp_http_router.py` - 新規作成（HTTPトランスポート）
-- `src/presentation/middleware/logging_middleware.py` - スキップパス追加
-- `src/presentation/middleware/request_id_middleware.py` - スキップパス追加
-- `src/main.py` - HTTPルーター登録
+- `src/presentation/mcp/mcp_http_transport.py` - 新規作成（HTTPトランスポート、`StreamableHTTPSessionManager`使用）
+- `src/presentation/middleware/logging_middleware.py` - スキップパス追加（`/mcp`を追加）
+- `src/presentation/middleware/request_id_middleware.py` - スキップパス追加（`/mcp`を追加）
+- `src/main.py` - HTTPトランスポートのマウントとlifespan設定
 - `README.md` - HTTPトランスポート設定例追加
 
 ### 参考にすべき既存コード
@@ -207,9 +209,19 @@ MCP仕様 2025-03-26 リビジョンで正式導入された Streamable HTTP ト
 - `handle_post_message`はASGIアプリなので`app.mount()`を使用（`app.include_router()`は使えない）
 
 #### Phase 2
-- ミドルウェアのスキップ処理は `/sse` と `/mcp` の両方に対応
-- AWS ECS + ALB環境での動作を考慮（タイムアウト設定など）
+- ミドルウェアのスキップ処理は `/sse` と `/mcp` の両方に対応（`path.startswith("/sse") or path.startswith("/mcp")`）
+- `StreamableHTTPSessionManager`を使用してHTTPトランスポートを実装
+- `main.py`の`lifespan`関数内で`session_manager.run()`を呼び出してタスクグループを初期化（必須）
+- HTTPトランスポートはASGIアプリとして`app.mount("/mcp", mcp_http_transport.http_app)`でマウント
 - SSEとHTTPの両方のトランスポートが同時に動作することを確認
+
+**Streamable HTTPで`app.mount()`を使う理由:**
+
+事実として以下が観察される:
+1. `StreamableHTTPSessionManager.handle_request()`はASGIインターフェース（`scope, receive, send`）を受け取り、`None`を返す
+2. FastAPIの`APIRouter`はFastAPIエンドポイント関数（`Request`, `Response`を扱う）を期待する
+3. これらは異なるインターフェースのため、`APIRouter`として直接登録できない
+4. そのため、ASGIアプリとしてラップし（`MCPHTTPApp`クラス）、`app.mount()`でマウントする
 
 ### MCP公式Python SDKの参考情報
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@
 
 import sys
 import uvicorn
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -25,6 +27,7 @@ from presentation.router import (
     lgtm_image_v2_router,
     mcp_sse_router,
 )
+from presentation.mcp import mcp_http_transport
 
 # 必須の環境変数を検証（起動時にfail-fast）
 try:
@@ -48,7 +51,21 @@ except Exception as e:
     print("Application will continue without Sentry error monitoring.", file=sys.stderr)
 
 
-app = FastAPI(title="LGTM Cat API")
+# FastAPIアプリケーションのlifespan設定
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """FastAPIアプリケーションのライフサイクル管理.
+
+    StreamableHTTPSessionManagerを初期化してタスクグループを作成します。
+    これにより、`app.mount()`でマウントされたMCP HTTPトランスポートが正常に動作します。
+    """
+    # StreamableHTTPSessionManagerを初期化
+    async with mcp_http_transport.session_manager.run():
+        yield
+
+
+# FastAPIアプリケーション作成
+app = FastAPI(title="LGTM Cat API", lifespan=lifespan)
 
 
 # 例外ハンドラの登録（X-Request-Idヘッダーを追加）
@@ -108,6 +125,10 @@ app.include_router(mcp_sse_router.router)
 
 # SSEトランスポート用のPOSTメッセージハンドラをマウント
 app.mount(mcp_sse_router.SSE_MESSAGES_PATH, mcp_sse_router.sse.handle_post_message)
+
+# MCP HTTPトランスポート（認証不要）
+# /mcpエンドポイントをASGIアプリとしてマウント（低レベルAPI使用）
+app.mount("/mcp", mcp_http_transport.http_app)
 
 
 def start() -> None:

--- a/src/presentation/mcp/mcp_http_transport.py
+++ b/src/presentation/mcp/mcp_http_transport.py
@@ -1,0 +1,40 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+
+"""MCP HTTPトランスポート実装.
+
+StreamableHTTPSessionManagerを使用したMCPサーバーのHTTPトランスポート。
+ASGIアプリとしてFastAPIの `/mcp` パスにマウントされます。
+"""
+
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from config import get_mcp_allowed_hosts
+from presentation.mcp.mcp_server import create_mcp_server
+
+# StreamableHTTPSessionManagerを初期化
+# DNS rebinding攻撃を防ぐため、許可されたホストのみを受け入れる
+session_manager = StreamableHTTPSessionManager(
+    create_mcp_server(),
+    security_settings=TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=get_mcp_allowed_hosts(),
+        allowed_origins=[],  # MCPプロトコルではOriginチェック不要
+    ),
+)
+
+
+class MCPHTTPApp:
+    """StreamableHTTPSessionManagerをASGIアプリとしてラップするクラス."""
+
+    def __init__(self, session_manager: StreamableHTTPSessionManager) -> None:
+        self.session_manager = session_manager
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """ASGIアプリケーションのエントリーポイント."""
+        await self.session_manager.handle_request(scope, receive, send)
+
+
+# ASGIアプリとしてエクスポート
+http_app: ASGIApp = MCPHTTPApp(session_manager)

--- a/src/presentation/mcp/mcp_http_transport.py
+++ b/src/presentation/mcp/mcp_http_transport.py
@@ -17,6 +17,8 @@ from presentation.mcp.mcp_server import create_mcp_server
 # DNS rebinding攻撃を防ぐため、許可されたホストのみを受け入れる
 session_manager = StreamableHTTPSessionManager(
     create_mcp_server(),
+    stateless=True,
+    json_response=True,
     security_settings=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
         allowed_hosts=get_mcp_allowed_hosts(),

--- a/src/presentation/middleware/logging_middleware.py
+++ b/src/presentation/middleware/logging_middleware.py
@@ -20,9 +20,11 @@ class LoggingMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # SSEエンドポイントはロギングをスキップ
+        # MCPエンドポイント（SSE、Streamable HTTP）はロギングをスキップ
+        # SSE: 長時間接続のため、通常のHTTPリクエストとログ出力の性質が異なる
+        # Streamable HTTP: 同様に長時間接続またはストリーミングレスポンスのため
         path = scope.get("path", "")
-        if path.startswith("/sse"):
+        if path.startswith("/sse") or path.startswith("/mcp"):
             await self.app(scope, receive, send)
             return
 

--- a/src/presentation/middleware/request_id_middleware.py
+++ b/src/presentation/middleware/request_id_middleware.py
@@ -17,9 +17,10 @@ class RequestIdMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # SSEエンドポイントはリクエストID処理をスキップ
+        # MCPエンドポイント（SSE、Streamable HTTP）はリクエストID処理をスキップ
+        # LoggingMiddlewareでログを出力しないため、リクエストIDを生成・設定する意味がない
         path = scope.get("path", "")
-        if path.startswith("/sse"):
+        if path.startswith("/sse") or path.startswith("/mcp"):
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-api/issues/93

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- MCP Streamable HTTPトランスポートの実装（`/mcp`エンドポイント）
- ミドルウェアのスキップ処理を`/mcp`パスにも対応
- README.mdへのStreamable HTTPトランスポート設定例の追加

**対応しない範囲:**
- SSEトランスポートの実装（既にPhase 1で完了）
- MCPツールの追加・変更（既存の3つのツールのみ提供）

# 変更点概要

MCP仕様 2025-03-26 リビジョンで正式導入されたStreamable HTTPトランスポートを追加した。これにより、将来的なSSEの非推奨化に備える。

**利用可能なMCPエンドポイント:**
- `/sse` - SSEトランスポート（既存）
- `/mcp` - Streamable HTTPトランスポート（新規追加）

既存のMCPツール（`get_random_lgtm_images`, `get_recently_created_lgtm_images`, `get_random_lgtm_markdown`）はどちらのトランスポートでも利用可能である。

Streamable HTTPトランスポートには、SSEトランスポートと同様のセキュリティ設定（DNS rebinding攻撃対策）を適用している。

# 補足情報

- Phase 1（MCP公式Python SDKへの基本移行）は既に完了済み
- このPRはPhase 2（Streamable HTTPトランスポートの追加）に対応

## StreamableHTTPSessionManagerの設定

MCP Python SDK公式ドキュメントの推奨に従い、以下のパラメータを設定:

- **`stateless=True`**: リクエストごとに新しいトランスポートを生成し、セッション状態を保持しない（HTTP本来のステートレスな特性に合致）
- **`json_response=True`**: SSEストリームではなく標準的なJSON形式でレスポンスを返す（一般的なHTTP APIクライアントとの互換性向上）

参考: https://github.com/modelcontextprotocol/python-sdk/blob/main/README.md#streamable-http-transport